### PR TITLE
Bug 1231 ehdollinen vastaanotto ei toimi sijoittelua kayttavissa erillishauissa

### DIFF
--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
@@ -507,7 +507,6 @@ class ValintatulosService(vastaanotettavuusService: VastaanotettavuusService,
       .map(peruValmistaAlemmatKeskeneräisetJosKäytetäänSijoittelua)
       .map(näytäVarasijaltaHyväksytytHyväksyttyinäJosVarasijasäännötEiVoimassa)
       .map(sovellaKorkeakoulujenVarsinaisenYhteishaunSääntöjä)
-      .map(sovellaKorkeakoulujenLisähaunSääntöjä)
       .map(näytäAlemmatPeruutuneetKeskeneräisinäJosYlemmätKeskeneräisiä)
       .map(piilotaKuvauksetKeskeneräisiltä)
       .map(asetaVastaanotettavuusValintarekisterinPerusteella(vastaanottoKaudella))
@@ -647,23 +646,6 @@ class ValintatulosService(vastaanotettavuusService: VastaanotettavuusService,
           tulos.copy(valintatila = Valintatila.peruuntunut, vastaanotettavuustila = Vastaanotettavuustila.ei_vastaanotettavissa)
         case (tulos, index) =>
           tulos
-      }
-    } else {
-      tulokset
-    }
-  }
-
-  private def sovellaKorkeakoulujenLisähaunSääntöjä(tulokset: List[Hakutoiveentulos], haku: Haku, ohjausparametrit: Option[Ohjausparametrit]) = {
-    if (haku.korkeakoulu && haku.yhteishaku && haku.lisähaku) {
-      if (tulokset.count(_.vastaanottotila == Vastaanottotila.vastaanottanut) > 0) {
-        // Peru muut kesken toiveet, jokin vastaanotettu
-        tulokset.map( tulos => if (List(Vastaanottotila.kesken).contains(tulos.vastaanottotila)) {
-          tulos.copy(valintatila = Valintatila.peruuntunut, vastaanotettavuustila = Vastaanotettavuustila.ei_vastaanotettavissa)
-        } else {
-          tulos
-        })
-      } else {
-        tulokset
       }
     } else {
       tulokset

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
@@ -506,7 +506,7 @@ class ValintatulosService(vastaanotettavuusService: VastaanotettavuusService,
       .map(näytäJulkaisematontaAlemmatPeruutetutKeskeneräisinä)
       .map(peruValmistaAlemmatKeskeneräisetJosKäytetäänSijoittelua)
       .map(näytäVarasijaltaHyväksytytHyväksyttyinäJosVarasijasäännötEiVoimassa)
-      .map(sovellaKorkeakoulujenVarsinaisenYhteishaunSääntöjä)
+      .map(sovellaSijoitteluaKayttanvaKorkeakouluhaunSaantoja)
       .map(näytäAlemmatPeruutuneetKeskeneräisinäJosYlemmätKeskeneräisiä)
       .map(piilotaKuvauksetKeskeneräisiltä)
       .map(asetaVastaanotettavuusValintarekisterinPerusteella(vastaanottoKaudella))
@@ -611,8 +611,8 @@ class ValintatulosService(vastaanotettavuusService: VastaanotettavuusService,
     } else ValintatuloksenTila.KESKEN
   }
 
-  private def sovellaKorkeakoulujenVarsinaisenYhteishaunSääntöjä(tulokset: List[Hakutoiveentulos], haku: Haku, ohjausparametrit: Option[Ohjausparametrit]) = {
-    if (haku.korkeakoulu && haku.yhteishaku && haku.varsinainenhaku) {
+  private def sovellaSijoitteluaKayttanvaKorkeakouluhaunSaantoja(tulokset: List[Hakutoiveentulos], haku: Haku, ohjausparametrit: Option[Ohjausparametrit]) = {
+    if (haku.korkeakoulu && haku.käyttääSijoittelua) {
       val firstVaralla = tulokset.indexWhere(_.valintatila == Valintatila.varalla)
       val firstVastaanotettu = tulokset.indexWhere(_.vastaanottotila == Vastaanottotila.vastaanottanut)
       val firstKesken = tulokset.indexWhere(_.valintatila == Valintatila.kesken)

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosServlet.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosServlet.scala
@@ -25,7 +25,7 @@ abstract class ValintatulosServlet(valintatulosService: ValintatulosService, vas
       Hakutoiveentulos.julkaistavaVersioSijoittelunTuloksesta(
         HakutoiveenSijoitteluntulos.kesken("1.2.3.4", "4.4.4.4"),
         Hakutoive("1.2.3.4", "4.4.4.4", "Hakukohde1", "Tarjoaja1"),
-        Haku("5.5.5.5", true, true, true, false, true, None, Set(),
+        Haku("5.5.5.5", korkeakoulu = true, käyttääSijoittelua = true, None, Set(),
           List(Hakuaika("12345", Some(System.currentTimeMillis()), Some(System.currentTimeMillis()))),
           Some(Kausi("2016S")),
           YhdenPaikanSaanto(false, ""), Map("kieli_fi" -> "Haun nimi")),

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/tarjonta/HakuService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/tarjonta/HakuService.scala
@@ -33,7 +33,7 @@ object HakuService {
   }
 }
 
-case class Haku(oid: String, korkeakoulu: Boolean, yhteishaku: Boolean, varsinainenhaku: Boolean, lisähaku: Boolean,
+case class Haku(oid: String, korkeakoulu: Boolean,
                 käyttääSijoittelua: Boolean, varsinaisenHaunOid: Option[String], sisältyvätHaut: Set[String],
                 hakuAjat: List[Hakuaika], koulutuksenAlkamiskausi: Option[Kausi], yhdenPaikanSaanto: YhdenPaikanSaanto,
                 nimi: Map[String, String])
@@ -102,7 +102,7 @@ protected trait JsonHakuService {
           } else throw new MappingException(s"Haku ${haku.oid} has unrecognized kausi URI '${haku.koulutuksenAlkamiskausiUri.get}' . Full data of haku: $haku")
     } else None
 
-    Haku(haku.oid, korkeakoulu, yhteishaku, varsinainenhaku, lisähaku, haku.sijoittelu, haku.parentHakuOid,
+    Haku(haku.oid, korkeakoulu, haku.sijoittelu, haku.parentHakuOid,
       haku.sisaltyvatHaut, haku.hakuaikas, kausi, haku.yhdenPaikanSaanto, haku.nimi)
   }
 }

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/HakutoiveenIlmoittautumistilaSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/HakutoiveenIlmoittautumistilaSpec.scala
@@ -16,15 +16,15 @@ class HakutoiveenIlmoittautumistilaSpec extends Specification {
   "Ilmoittautuminen" should {
     "should be enabled in IT" in {
       implicit val appConfig = new AppConfig.IT
-      val it = HakutoiveenIlmoittautumistila.getIlmoittautumistila(vastaanottanut, Haku("", true, true, true, false,
-        true, None, Set(), Nil, Some(Kausi("2016S")), YhdenPaikanSaanto(false, ""), Map("kieli_fi" -> "Haun nimi")), None)
+      val it = HakutoiveenIlmoittautumistila.getIlmoittautumistila(vastaanottanut, Haku("", korkeakoulu = true, käyttääSijoittelua = true,
+        None, Set(), Nil, Some(Kausi("2016S")), YhdenPaikanSaanto(false, ""), Map("kieli_fi" -> "Haun nimi")), None)
       it.ilmoittauduttavissa must_== true
     }
 
     "should be disabled by default" in {
       implicit val appConfig = new AppConfig.IT_disabledIlmoittautuminen
-      val it = HakutoiveenIlmoittautumistila.getIlmoittautumistila(vastaanottanut, Haku("", true, true, true, false,
-        true, None, Set(), Nil, Some(Kausi("2016S")), YhdenPaikanSaanto(false, ""), Map("kieli_fi" -> "Haun nimi")), None)
+      val it = HakutoiveenIlmoittautumistila.getIlmoittautumistila(vastaanottanut, Haku("", korkeakoulu = true, käyttääSijoittelua = true,
+        None, Set(), Nil, Some(Kausi("2016S")), YhdenPaikanSaanto(false, ""), Map("kieli_fi" -> "Haun nimi")), None)
       it.ilmoittauduttavissa must_== false
     }
   }

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceLisahakuSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceLisahakuSpec.scala
@@ -40,8 +40,8 @@ class ValintatulosServiceLisahakuSpec extends ITSpecification with TimeWarp {
         checkHakutoiveState(getHakutoive("1.2.246.562.14.2014022408541751568934"), Valintatila.hyväksytty, Vastaanottotila.kesken, Vastaanotettavuustila.vastaanotettavissa_sitovasti, true)
       }
       "toinen vastaanotettu, ensimmäistä ei voi vastaanottaa" in {
-        useFixture("lisahaku-vastaanottanut.json", hakuFixture = hakuFixture, hakemusFixtures = hakemusFixtures)
-        checkHakutoiveState(getHakutoive("1.2.246.562.14.2013120515524070995659"), Valintatila.peruuntunut, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
+        useFixture("lisahaku-vastaanottanut.json", hakuFixture = hakuFixture, hakemusFixtures = hakemusFixtures, yhdenPaikanSaantoVoimassa = true)
+        checkHakutoiveState(getHakutoive("1.2.246.562.14.2013120515524070995659"), Valintatila.peruuntunut, Vastaanottotila.ottanut_vastaan_toisen_paikan, Vastaanotettavuustila.ei_vastaanotettavissa, true)
         checkHakutoiveState(getHakutoive("1.2.246.562.14.2014022408541751568934"), Valintatila.hyväksytty, Vastaanottotila.vastaanottanut, Vastaanotettavuustila.ei_vastaanotettavissa, true)
       }
     }

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
@@ -24,68 +24,21 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
 
       testitKaikilleHakutyypeille(hakuFixture)
       testitSijoittelunPiirissäOlevilleHakutyypeille(hakuFixture)
-
-      "hyväksytty, korkeakoulujen yhteishaku" in {
-        "ylemmat sijoiteltu -> vastaanotettavissa" in {
-          useFixture("hyvaksytty-ylempi-sijoiteltu.json", hakuFixture = hakuFixture)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.hylätty, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.16303028779"), Valintatila.hyväksytty, Vastaanottotila.kesken, Vastaanotettavuustila.vastaanotettavissa_sitovasti, true)
-        }
-
-        "ylempi varalla, kun varasijasäännöt ei vielä voimassa -> kesken" in {
-          useFixture("hyvaksytty-ylempi-varalla.json", hakuFixture = hakuFixture, ohjausparametritFixture = OhjausparametritFixtures.varasijasaannotEiVielaVoimassa)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.varalla, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.16303028779"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
-        }
-
-        "ylempi sijoittelematon -> kesken" in {
-          useFixture("hyvaksytty-ylempi-sijoittelematon.json", hakuFixture = hakuFixture)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.16303028779"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
-        }
-
-        "ylempi varalla, kun varasijasäännöt voimassa -> ehdollisesti vastaanotettavissa" in {
-          useFixture("hyvaksytty-ylempi-varalla.json", hakuFixture = hakuFixture)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.varalla, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.16303028779"), Valintatila.hyväksytty, Vastaanottotila.kesken, Vastaanotettavuustila.vastaanotettavissa_ehdollisesti, true)
-        }
-
-        "ylempi varalla, kun varasijasäännöt voimassa, mutta vastaanotto päättynyt -> ei vastaanotettavissa" in {
-          useFixture("hyvaksytty-ylempi-varalla.json", hakuFixture = hakuFixture, ohjausparametritFixture =  "vastaanotto-loppunut")
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.varalla, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.16303028779"), Valintatila.hyväksytty, Vastaanottotila.ei_vastaanotettu_määräaikana, Vastaanotettavuustila.ei_vastaanotettavissa, true)
-        }
-
-        "hakutoiveista 1. kesken 2. hyväksytty 3. perutuuntunut" in {
-          useFixture("hyvaksytty-ylempi-sijoittelematon-alempi-peruuntunut.json", hakuFixture = hakuFixture, hakemusFixtures = List("00000441369-3"))
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738903"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738904"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
-        }
-      }
-
-      "peruuntunut, korkeakoulujen yhteishaku" in {
-        "ylempi hyväksytty kesken, koska varasijasäännöt ei vielä voimassa -> näytetään peruuntunut keskeneräisenä" in {
-          useFixture("varalla-julkaistu-peruuntunut.json", hakuFixture = hakuFixture, hakemusFixtures = List( "00000441369-3"), ohjausparametritFixture =  "varasijasaannot-ei-viela-voimassa")
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.varalla, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738903"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738904"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
-        }
-
-        "ylempi hyväksytty, kun varasijasäännöt ovat voimassa -> näytetään todellinen tilanne" in {
-          useFixture("varalla-julkaistu-peruuntunut.json", hakuFixture = hakuFixture, hakemusFixtures = List( "00000441369-3"))
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.varalla, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738903"), Valintatila.hyväksytty, Vastaanottotila.kesken, Vastaanotettavuustila.vastaanotettavissa_ehdollisesti, true)
-          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738904"), Valintatila.peruuntunut, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
-        }
-      }
+      testitSijoiteltavilleKorkeakouluHauille(hakuFixture)
     }
 
     "erillishaku korkeakouluihin" in {
       val hakuFixture: String = HakuFixtures.korkeakouluErillishaku
       testitKaikilleHakutyypeille(hakuFixture)
-      testitTyypillisilleHauille(hakuFixture)
+      testitSijoiteltavilleKorkeakouluHauille(hakuFixture)
       testitSijoittelunPiirissäOlevilleHakutyypeille(hakuFixture)
+    }
+
+    "korkeakoulun yhteishaku ilman sijoittelua" in {
+      val hakuFixture: String = "korkeakoulu-lisahaku1"
+      testitKaikilleHakutyypeille(hakuFixture)
+      testitTyypillisilleHauille(hakuFixture)
+      testitSijoittelunPiirissäOlemattomilleHakutyypeille(hakuFixture)
     }
 
     "yhteishaku toisen asteen oppilaitoksiin" in {
@@ -153,6 +106,63 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
         checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.hyväksytty, Vastaanottotila.kesken, Vastaanotettavuustila.vastaanotettavissa_sitovasti, true)
         checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738903"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
         checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738904"), Valintatila.hyväksytty, Vastaanottotila.kesken, Vastaanotettavuustila.vastaanotettavissa_sitovasti, true)
+      }
+    }
+
+    def testitSijoiteltavilleKorkeakouluHauille(hakuFixture: String) = {
+      "hyväksytty, sijoittelua käyttävä korkeakouluhaku" in {
+        "ylemmat sijoiteltu -> vastaanotettavissa" in {
+          useFixture("hyvaksytty-ylempi-sijoiteltu.json", hakuFixture = hakuFixture)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.hylätty, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.16303028779"), Valintatila.hyväksytty, Vastaanottotila.kesken, Vastaanotettavuustila.vastaanotettavissa_sitovasti, true)
+        }
+
+        "ylempi varalla, kun varasijasäännöt ei vielä voimassa -> kesken" in {
+          useFixture("hyvaksytty-ylempi-varalla.json", hakuFixture = hakuFixture, ohjausparametritFixture = OhjausparametritFixtures.varasijasaannotEiVielaVoimassa)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.varalla, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.16303028779"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
+        }
+
+        "ylempi sijoittelematon -> kesken" in {
+          useFixture("hyvaksytty-ylempi-sijoittelematon.json", hakuFixture = hakuFixture)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.16303028779"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
+        }
+
+        "ylempi varalla, kun varasijasäännöt voimassa -> ehdollisesti vastaanotettavissa" in {
+          useFixture("hyvaksytty-ylempi-varalla.json", hakuFixture = hakuFixture)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.varalla, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.16303028779"), Valintatila.hyväksytty, Vastaanottotila.kesken, Vastaanotettavuustila.vastaanotettavissa_ehdollisesti, true)
+        }
+
+        "ylempi varalla, kun varasijasäännöt voimassa, mutta vastaanotto päättynyt -> ei vastaanotettavissa" in {
+          useFixture("hyvaksytty-ylempi-varalla.json", hakuFixture = hakuFixture, ohjausparametritFixture =  "vastaanotto-loppunut")
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.varalla, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.16303028779"), Valintatila.hyväksytty, Vastaanottotila.ei_vastaanotettu_määräaikana, Vastaanotettavuustila.ei_vastaanotettavissa, true)
+        }
+
+        "hakutoiveista 1. kesken 2. hyväksytty 3. perutuuntunut" in {
+          useFixture("hyvaksytty-ylempi-sijoittelematon-alempi-peruuntunut.json", hakuFixture = hakuFixture, hakemusFixtures = List("00000441369-3"))
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738903"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738904"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
+        }
+      }
+
+      "peruuntunut, sijoittelua käyttävä korkeakouluhaku" in {
+        "ylempi hyväksytty kesken, koska varasijasäännöt ei vielä voimassa -> näytetään peruuntunut keskeneräisenä" in {
+          useFixture("varalla-julkaistu-peruuntunut.json", hakuFixture = hakuFixture, hakemusFixtures = List( "00000441369-3"), ohjausparametritFixture =  "varasijasaannot-ei-viela-voimassa")
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.varalla, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738903"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738904"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
+        }
+
+        "ylempi hyväksytty, kun varasijasäännöt ovat voimassa -> näytetään todellinen tilanne" in {
+          useFixture("varalla-julkaistu-peruuntunut.json", hakuFixture = hakuFixture, hakemusFixtures = List( "00000441369-3"))
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.varalla, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738903"), Valintatila.hyväksytty, Vastaanottotila.kesken, Vastaanotettavuustila.vastaanotettavissa_ehdollisesti, true)
+          checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738904"), Valintatila.peruuntunut, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
+        }
       }
     }
 

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/VastaanotettavuusServiceSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/VastaanotettavuusServiceSpec.scala
@@ -60,7 +60,7 @@ class VastaanotettavuusServiceSpec extends Specification with MockitoMatchers wi
 
   trait YhdenPaikanSaantoVoimassa extends Mockito with Scope with MustThrownExpectations { this: VastaanotettavuusServiceWithMocks =>
     val henkiloOid = "1.2.246.562.24.00000000000"
-    val haku = Haku("1.2.246.562.29.00000000000", true, true, true, false, true, None, Set(), List(),
+    val haku = Haku("1.2.246.562.29.00000000000", korkeakoulu = true, käyttääSijoittelua = true, None, Set(), List(),
       Some(Kausi("2016S")), YhdenPaikanSaanto(true, "kk haku ilman kohdejoukon tarkennetta"), Map("kieli_fi" -> "Haun nimi"))
     val koulutusOid = "1.2.246.562.17.00000000000"
     val hakukohde = Hakukohde("1.2.246.562.20.00000000000", haku.oid, List(koulutusOid), "KORKEAKOULUTUS", "TUTKINTO",
@@ -80,7 +80,7 @@ class VastaanotettavuusServiceSpec extends Specification with MockitoMatchers wi
   trait IlmanYhdenPaikanSaantoa extends Mockito with Scope with MustThrownExpectations { this: VastaanotettavuusServiceWithMocks =>
     val henkiloOid = "1.2.246.562.24.00000000000"
     val hakemusOid = "1.2.246.562.99.00000000000"
-    val haku = Haku("1.2.246.562.29.00000000001", true, true, true, false, true, None, Set(), List(),
+    val haku = Haku("1.2.246.562.29.00000000001", true, true, None, Set(), List(),
       Some(Kausi("2016S")), YhdenPaikanSaanto(false, "ei kk haku"), Map("kieli_fi" -> "Haun nimi"))
     val koulutusOid = "1.2.246.562.17.00000000001"
     val hakukohde = Hakukohde("1.2.246.562.20.00000000001", haku.oid, List(koulutusOid), "AMMATILLINEN_PERUSKOULUTUS",

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/testenvironment/TarjontaIntegrationTest.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/testenvironment/TarjontaIntegrationTest.scala
@@ -12,7 +12,7 @@ class TarjontaIntegrationTest extends Specification {
     "Extract response from tarjonta API"in {
       val haku = new TarjontaHakuService(null, new AppConfig.IT).getHaku("1.2.246.562.5.2013080813081926341927").right.get
       haku.korkeakoulu must_== false
-      haku.yhteishaku must_== true
+      haku.varsinaisenHaunOid must_== None
     }
   }
 

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/valintarekisteri/HakukohdeRecordServiceSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/valintarekisteri/HakukohdeRecordServiceSpec.scala
@@ -86,9 +86,7 @@ class HakukohdeRecordServiceSpec extends Specification with MockitoMatchers with
     val yhdenpaikansaanto = YhdenPaikanSaanto(voimassa = true, "Korkeakoulutus ilman kohdejoukon tarkennetta")
     val hakukohdeFromTarjonta = Hakukohde(hakukohdeOid, hakuOid, List(julkaistuKoulutus.oid), "KORKEAKOULUTUS", "TUTKINTO",
       Map("kieli_fi" -> "Hakukohteen nimi"), Map("fi" -> "Tarjoajan nimi"), yhdenPaikanSaanto = yhdenpaikansaanto)
-    val hakuFromTarjonta: Haku = Haku(hakuOid, korkeakoulu = true, yhteishaku = true, varsinainenhaku = true,
-      lisähaku = false, käyttääSijoittelua = true, varsinaisenHaunOid = None, sisältyvätHaut = Set(), hakuAjat = Nil,
-      Some(Kausi("2016K")), yhdenpaikansaanto,
-      Map("kieli_fi" -> "Haun nimi"))
+    val hakuFromTarjonta: Haku = Haku(hakuOid, korkeakoulu = true, käyttääSijoittelua = true, varsinaisenHaunOid = None,
+      sisältyvätHaut = Set(), hakuAjat = Nil, Some(Kausi("2016K")), yhdenpaikansaanto, Map("kieli_fi" -> "Haun nimi"))
   }
 }


### PR DESCRIPTION
https://jira.oph.ware.fi/jira/browse/BUG-1231

Muutetaan ehdoksi yhteishaun tilalle se, että käytetään sijoittelua.

Poistetaan samalla lisähakujen muiden toiveiden peruunnuttaminen vastaanoton yhteydessä, koska tämä pitäisi nykyisin hoitua yhden paikan säännöksellä silloin kun se on tarpeen, ja jos tulisi vastaan sellainen teoreettinen tapaus että lisähaku ei ole yhden paikan säännöksen piirissä, tätä ei kuulu tehdä.

Ja vielä voi poistaa tarjonnasta parsittavalta haulta yhteishaku-, varsinainenHaku- ja lisäHaku-täpät, joita ei enää käytetä.