### PR TITLE
Move tilankuvaus_hash mappings to separate table

### DIFF
--- a/valinta-tulos-valintarekisteri-db/src/main/resources/db/migration/V57__valinnantilat_valinnantilan_kuvaukset.sql
+++ b/valinta-tulos-valintarekisteri-db/src/main/resources/db/migration/V57__valinnantilat_valinnantilan_kuvaukset.sql
@@ -2,6 +2,7 @@ set session_replication_role = replica; -- disable triggers for this session
 
 create table tilat_kuvaukset (
     tilankuvaus_hash bigint not null,
+    tarkenteen_lisatieto character varying null,
     hakukohde_oid character varying not null,
     valintatapajono_oid character varying not null,
     hakemus_oid character varying not null,
@@ -13,12 +14,14 @@ create table tilat_kuvaukset_history (like tilat_kuvaukset);
 
 insert into tilat_kuvaukset_history (
     tilankuvaus_hash,
+    tarkenteen_lisatieto,
     hakukohde_oid,
     valintatapajono_oid,
     hakemus_oid,
     transaction_id,
     system_time
 ) select tilankuvaus_hash,
+    tarkenteen_lisatieto,
     hakukohde_oid,
     valintatapajono_oid,
     hakemus_oid,
@@ -28,12 +31,14 @@ insert into tilat_kuvaukset_history (
 
 insert into tilat_kuvaukset (
     tilankuvaus_hash,
+    tarkenteen_lisatieto,
     hakukohde_oid,
     valintatapajono_oid,
     hakemus_oid,
     transaction_id,
     system_time
 ) select tilankuvaus_hash,
+    tarkenteen_lisatieto,
     hakukohde_oid,
     valintatapajono_oid,
     hakemus_oid,
@@ -42,8 +47,11 @@ insert into tilat_kuvaukset (
   from valinnantulokset where tilankuvaus_hash is not null;
 
 alter table jonosijat drop column tilankuvaus_hash;
+alter table jonosijat drop column tarkenteen_lisatieto;
 alter table valinnantulokset_history drop column tilankuvaus_hash;
+alter table valinnantulokset_history drop column tarkenteen_lisatieto;
 alter table valinnantulokset drop column tilankuvaus_hash;
+alter table valinnantulokset drop column tarkenteen_lisatieto;
 
 alter table tilat_kuvaukset add primary key (valintatapajono_oid, hakemus_oid, hakukohde_oid);
 
@@ -62,6 +70,7 @@ $$
 begin
     insert into tilat_kuvaukset_history (
         tilankuvaus_hash,
+        tarkenteen_lisatieto,
         hakukohde_oid,
         valintatapajono_oid,
         hakemus_oid,
@@ -69,6 +78,7 @@ begin
         system_time
     ) values (
         old.tilankuvaus_hash,
+        old.tarkenteen_lisatieto,
         old.hakukohde_oid,
         old.valintatapajono_oid,
         old.hakemus_oid,
@@ -100,7 +110,6 @@ begin
         hakukohde_oid,
         valintatapajono_oid,
         hakemus_oid,
-        tarkenteen_lisatieto,
         julkaistavissa,
         ehdollisesti_hyvaksyttavissa,
         hyvaksytty_varasijalta,
@@ -113,7 +122,6 @@ begin
         old.hakukohde_oid,
         old.valintatapajono_oid,
         old.hakemus_oid,
-        old.tarkenteen_lisatieto,
         old.julkaistavissa,
         old.ehdollisesti_hyvaksyttavissa,
         old.hyvaksytty_varasijalta,

--- a/valinta-tulos-valintarekisteri-db/src/main/resources/db/migration/V57__valinnantilat_valinnantilan_kuvaukset.sql
+++ b/valinta-tulos-valintarekisteri-db/src/main/resources/db/migration/V57__valinnantilat_valinnantilan_kuvaukset.sql
@@ -45,7 +45,7 @@ alter table jonosijat drop column tilankuvaus_hash;
 alter table valinnantulokset_history drop column tilankuvaus_hash;
 alter table valinnantulokset drop column tilankuvaus_hash;
 
-alter table tilat_kuvaukset add primary key (tilankuvaus_hash, valintatapajono_oid, hakemus_oid);
+alter table tilat_kuvaukset add primary key (valintatapajono_oid, hakemus_oid, hakukohde_oid);
 
 create trigger set_temporal_columns_on_tilat_kuvaukset_on_insert
 before insert on tilat_kuvaukset
@@ -90,8 +90,8 @@ after delete on tilat_kuvaukset
 for each row
 execute procedure update_tilat_kuvaukset_history();
 
-alter table tilat_kuvaukset add foreign key (hakukohde_oid, valintatapajono_oid, hakemus_oid)
-references valinnantilat (hakukohde_oid, valintatapajono_oid, hakemus_oid);
+alter table tilat_kuvaukset add foreign key (valintatapajono_oid, hakemus_oid, hakukohde_oid)
+references valinnantilat (valintatapajono_oid, hakemus_oid, hakukohde_oid);
 
 create or replace function update_valinnantulokset_history() returns trigger as
 $$
@@ -127,5 +127,6 @@ begin
 end;
 $$ language plpgsql;
 
+analyze tilat_kuvaukset;
 
 set session_replication_role = default; -- enable triggers for this session

--- a/valinta-tulos-valintarekisteri-db/src/main/resources/db/migration/V57__valinnantilat_valinnantilan_kuvaukset.sql
+++ b/valinta-tulos-valintarekisteri-db/src/main/resources/db/migration/V57__valinnantilat_valinnantilan_kuvaukset.sql
@@ -2,9 +2,9 @@ set session_replication_role = replica; -- disable triggers for this session
 
 create table tilat_kuvaukset (
     tilankuvaus_hash bigint not null,
-    hakukohde_oid text not null,
-    valintatapajono_oid text not null,
-    hakemus_oid text not null,
+    hakukohde_oid character varying not null,
+    valintatapajono_oid character varying not null,
+    hakemus_oid character varying not null,
     transaction_id bigint not null default txid_current(),
     system_time tstzrange not null default tstzrange(now(), null, '[)')
 );

--- a/valinta-tulos-valintarekisteri-db/src/main/resources/db/migration/V57__valinnantilat_valinnantilan_kuvaukset.sql
+++ b/valinta-tulos-valintarekisteri-db/src/main/resources/db/migration/V57__valinnantilat_valinnantilan_kuvaukset.sql
@@ -1,0 +1,131 @@
+set session_replication_role = replica; -- disable triggers for this session
+
+create table tilat_kuvaukset (
+    tilankuvaus_hash bigint not null,
+    hakukohde_oid text not null,
+    valintatapajono_oid text not null,
+    hakemus_oid text not null,
+    transaction_id bigint not null default txid_current(),
+    system_time tstzrange not null default tstzrange(now(), null, '[)')
+);
+
+create table tilat_kuvaukset_history (like tilat_kuvaukset);
+
+insert into tilat_kuvaukset_history (
+    tilankuvaus_hash,
+    hakukohde_oid,
+    valintatapajono_oid,
+    hakemus_oid,
+    transaction_id,
+    system_time
+) select tilankuvaus_hash,
+    hakukohde_oid,
+    valintatapajono_oid,
+    hakemus_oid,
+    transaction_id,
+    system_time
+  from valinnantulokset_history where tilankuvaus_hash is not null;
+
+insert into tilat_kuvaukset (
+    tilankuvaus_hash,
+    hakukohde_oid,
+    valintatapajono_oid,
+    hakemus_oid,
+    transaction_id,
+    system_time
+) select tilankuvaus_hash,
+    hakukohde_oid,
+    valintatapajono_oid,
+    hakemus_oid,
+    transaction_id,
+    system_time
+  from valinnantulokset where tilankuvaus_hash is not null;
+
+alter table jonosijat drop column tilankuvaus_hash;
+alter table valinnantulokset_history drop column tilankuvaus_hash;
+alter table valinnantulokset drop column tilankuvaus_hash;
+
+alter table tilat_kuvaukset add primary key (tilankuvaus_hash, valintatapajono_oid, hakemus_oid);
+
+create trigger set_temporal_columns_on_tilat_kuvaukset_on_insert
+before insert on tilat_kuvaukset
+for each row
+execute procedure set_temporal_columns();
+
+create trigger set_temporal_columns_on_tilat_kuvaukset_on_update
+before update on tilat_kuvaukset
+for each row
+execute procedure set_temporal_columns();
+
+create or replace function update_tilat_kuvaukset_history() returns trigger as
+$$
+begin
+    insert into tilat_kuvaukset_history (
+        tilankuvaus_hash,
+        hakukohde_oid,
+        valintatapajono_oid,
+        hakemus_oid,
+        transaction_id,
+        system_time
+    ) values (
+        old.tilankuvaus_hash,
+        old.hakukohde_oid,
+        old.valintatapajono_oid,
+        old.hakemus_oid,
+        old.transaction_id,
+        tstzrange(lower(old.system_time), now(), '[)')
+    );
+    return null;
+end;
+$$ language plpgsql;
+
+create trigger tilat_kuvaukset_history
+after update on tilat_kuvaukset
+for each row
+when (old.transaction_id <> txid_current())
+execute procedure update_tilat_kuvaukset_history();
+
+create trigger delete_tilat_kuvaukset_history
+after delete on tilat_kuvaukset
+for each row
+execute procedure update_tilat_kuvaukset_history();
+
+alter table tilat_kuvaukset add foreign key (hakukohde_oid, valintatapajono_oid, hakemus_oid)
+references valinnantilat (hakukohde_oid, valintatapajono_oid, hakemus_oid);
+
+create or replace function update_valinnantulokset_history() returns trigger as
+$$
+begin
+    insert into valinnantulokset_history (
+        hakukohde_oid,
+        valintatapajono_oid,
+        hakemus_oid,
+        tarkenteen_lisatieto,
+        julkaistavissa,
+        ehdollisesti_hyvaksyttavissa,
+        hyvaksytty_varasijalta,
+        hyvaksy_peruuntunut,
+        ilmoittaja,
+        selite,
+        system_time,
+        transaction_id
+    ) values (
+        old.hakukohde_oid,
+        old.valintatapajono_oid,
+        old.hakemus_oid,
+        old.tarkenteen_lisatieto,
+        old.julkaistavissa,
+        old.ehdollisesti_hyvaksyttavissa,
+        old.hyvaksytty_varasijalta,
+        old.hyvaksy_peruuntunut,
+        old.ilmoittaja,
+        old.selite,
+        tstzrange(lower(old.system_time), now(), '[)'),
+        old.transaction_id
+    );
+    return null;
+end;
+$$ language plpgsql;
+
+
+set session_replication_role = default; -- enable triggers for this session

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/ValintarekisteriDb.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/ValintarekisteriDb.scala
@@ -901,10 +901,11 @@ class ValintarekisteriDb(dbConfig: Config, isItProfile:Boolean = false) extends 
             on vt.valintatapajono_oid = v.valintatapajono_oid
               and vt.hakemus_oid = v.hakemus_oid
               and vt.hakukohde_oid = v.hakukohde_oid
-            inner join vj on vj.oid = j.valintatapajono_oid
             join tilat_kuvaukset t_k
-            on v.valintatapajono_oid = t_k.valintatapajono_oid
-              and v.hakemus_oid = t_k.hakemus_oid
+            on t_k.valintatapajono_oid = vt.valintatapajono_oid
+              and t_k.hakemus_oid = vt.hakemus_oid
+              and t_k.hakukohde_oid = vt.hakukohde_oid
+            inner join vj on vj.oid = j.valintatapajono_oid
             where j.sijoitteluajo_id = ${sijoitteluajoId}""".as[HakemusRecord]).toList match {
         case result if result.size == 0 => result
         case result => result ++ readHakemukset(offset + chunkSize)

--- a/valinta-tulos-valintarekisteri-db/src/test/scala/fi/vm/sade/valintatulosservice/valintarekisteri/ValintarekisteriDbTools.scala
+++ b/valinta-tulos-valintarekisteri-db/src/test/scala/fi/vm/sade/valintatulosservice/valintarekisteri/ValintarekisteriDbTools.scala
@@ -348,7 +348,7 @@ trait ValintarekisteriDbTools extends Specification {
     singleConnectionValintarekisteriDb.runBlocking(
       sql"""select j.hakemus_oid, j.hakija_oid, j.etunimi, j.sukunimi, j.prioriteetti, j.jonosija, j.varasijan_numero,
             j.onko_muuttunut_viime_sijoittelussa, j.pisteet, j.tasasijajonosija, j.hyvaksytty_harkinnanvaraisesti,
-            j.siirtynyt_toisesta_valintatapajonosta, vt.tila, t_k.tilankuvaus_hash, v.tarkenteen_lisatieto, t.tilan_tarkenne, v.tarkenteen_lisatieto, array_to_string(array_agg(hr.oid) , ',')
+            j.siirtynyt_toisesta_valintatapajonosta, vt.tila, t_k.tilankuvaus_hash, t_k.tarkenteen_lisatieto, t.tilan_tarkenne, t_k.tarkenteen_lisatieto, array_to_string(array_agg(hr.oid) , ',')
             from jonosijat j
             left join hakijaryhman_hakemukset as hh on hh.hakemus_oid = j.hakemus_oid
             left join hakijaryhmat as hr on hr.oid = hh.hakijaryhma_oid and hr.sijoitteluajo_id = hh.sijoitteluajo_id
@@ -359,7 +359,7 @@ trait ValintarekisteriDbTools extends Specification {
             where j.valintatapajono_oid = ${valintatapajonoOid}
             group by j.hakemus_oid, j.hakija_oid, j.etunimi, j.sukunimi, j.prioriteetti, j.jonosija, j.varasijan_numero,
             j.onko_muuttunut_viime_sijoittelussa, j.pisteet, j.tasasijajonosija, j.hyvaksytty_harkinnanvaraisesti,
-            j.siirtynyt_toisesta_valintatapajonosta, vt.tila, t_k.tilankuvaus_hash, t.tilan_tarkenne, v.tarkenteen_lisatieto
+            j.siirtynyt_toisesta_valintatapajonosta, vt.tila, t_k.tilankuvaus_hash, t.tilan_tarkenne, t_k.tarkenteen_lisatieto
          """.as[Hakemus])
   }
 


### PR DESCRIPTION
This allows us to remove the duplicated hash from
jonosijat and valinnantulokset tables.
No functional changes, I hope.

NB: For the time being there's a performance issue in reading.