### PR TITLE
BUG-1346 : Allow empty hakutoiveet of hakemus

### DIFF
--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/hakemus/HakemusRepository.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/hakemus/HakemusRepository.scala
@@ -97,10 +97,18 @@ class HakemusRepository()(implicit appConfig: VtsAppConfig) extends Logging {
       henkiloOid <- data.getAs[String](DatabaseKeys.personOidKey)
       answers <- data.getAs[MongoDBObject](DatabaseKeys.answersKey)
       asiointikieli = parseAsiointikieli(answers.expand[String](DatabaseKeys.asiointiKieliKey))
-      hakutoiveet <- answers.getAs[MongoDBObject](DatabaseKeys.hakutoiveetKey)
+      hakutoiveet <- extractHakutoiveet(answers)
       henkilotiedot <- answers.getAs[MongoDBObject]("henkilotiedot")
     } yield {
       Hakemus(hakemusOid, hakuOid, henkiloOid, asiointikieli, parseHakutoiveet(hakutoiveet), parseHenkilotiedot(henkilotiedot))
+    }
+  }
+
+  private def extractHakutoiveet(answers: MongoDBObject): Option[MongoDBObject] = {
+    if (answers.containsField(DatabaseKeys.hakutoiveetKey)) {
+      answers.getAs[MongoDBObject](DatabaseKeys.hakutoiveetKey)
+    } else {
+      None
     }
   }
 


### PR DESCRIPTION
Fixes this:
Caused by: java.lang.ClassCastException: scala.None$ cannot be cast to com.mongodb.BasicDBObject
...at com.mongodb.casbah.commons.MongoDBObject.getAs(MongoDBObject.scala:143)
at fi.vm.sade.valintatulosservice.hakemus.HakemusRepository$$anonfun$fi$vm$$$$$597e7e3ae2ec62f6187e8346a2f18$$$$$anonfun$apply$5$$anonfun$apply$6$$anonfun$apply$8.apply(HakemusRepository.scala:100)