### PR TITLE
BUG-1758 : Suren kkhakijat-API hidastelee

### DIFF
--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/LukuvuosimaksuService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/LukuvuosimaksuService.scala
@@ -18,6 +18,22 @@ class LukuvuosimaksuService(lukuvuosimaksuRepository: LukuvuosimaksuRepository,
         .build(),
       new Changes.Builder().build()
     )
+    filterRelevantMaksusOfEachperson(result)
+  }
+
+  def getLukuvuosimaksut(hakukohdeOids: Set[HakukohdeOid], auditInfo: AuditInfo): Seq[Lukuvuosimaksu] = {
+    val result = lukuvuosimaksuRepository.getLukuvuosimaksus(hakukohdeOids)
+    audit.log(auditInfo.user, LukuvuosimaksujenLuku,
+      new Target.Builder()
+        .setField("hakukohde", hakukohdeOids.mkString(","))
+        .setField("muokkaaja", "")
+        .build(),
+      new Changes.Builder().build()
+    )
+    filterRelevantMaksusOfEachperson(result)
+  }
+
+  private def filterRelevantMaksusOfEachperson(result: List[Lukuvuosimaksu]) = {
     result
       .groupBy(l => l.personOid).values
       .map(l => l.sortBy(a => a.luotu).reverse)

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/LukuvuosimaksuServletSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/LukuvuosimaksuServletSpec.scala
@@ -1,5 +1,7 @@
 package fi.vm.sade.valintatulosservice.local
 
+import java.util.Date
+
 import fi.vm.sade.valintatulosservice._
 import fi.vm.sade.valintatulosservice.config.VtsAppConfig
 import fi.vm.sade.valintatulosservice.lukuvuosimaksut.LukuvuosimaksuMuutos
@@ -7,6 +9,7 @@ import fi.vm.sade.valintatulosservice.valintarekisteri.ValintarekisteriDbTools
 import fi.vm.sade.valintatulosservice.valintarekisteri.domain._
 import org.json4s.{DefaultFormats, Formats}
 import org.json4s.ext.EnumNameSerializer
+import org.json4s.native.JsonParser
 import org.junit.runner.RunWith
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.model.{HttpRequest, HttpResponse}
@@ -42,6 +45,23 @@ class LukuvuosimaksuServletSpec extends ServletSpecification with Valintarekiste
     "fail with 400 when calling without 'auditInfo'" in {
       post(s"lukuvuosimaksu/write/1.2.3.200", muutosAsJson(vapautettu), httpHeaders) {
         status must_== 400
+      }
+    }
+    "find lukuvuosimaksut by several hakukohde oids" in {
+      val maksettavaKohde = HakukohdeOid("1.2.3.200")
+      post(s"lukuvuosimaksu/write/${maksettavaKohde.s}", muutosAsJsonWithAuditSession(maksettu), httpHeaders) {
+        status must_== 204
+      }
+      post("lukuvuosimaksu/read", serialiseToJson(LukuvuosimaksuBulkReadRequest(List(maksettavaKohde, HakukohdeOid("1.2.3.300")), auditSession)), httpHeaders) {
+        val maksut = JsonParser.parse(body).extract[Seq[Lukuvuosimaksu]]
+        maksut must have size 1
+        val maksu = maksut.head
+        maksu.personOid must_== maksettu.personOid
+        maksu.maksuntila must_== maksettu.maksuntila
+        maksu.hakukohdeOid must_== maksettavaKohde
+        maksu.muokkaaja must_== auditSession.personOid
+        maksu.luotu.getTime must be_< (System.currentTimeMillis() + (60 * 1000))
+        status must_== 200
       }
     }
   }

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/LukuvuosimaksuServletSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/LukuvuosimaksuServletSpec.scala
@@ -70,27 +70,19 @@ class LukuvuosimaksuServletSpec extends ServletSpecification with Valintarekiste
         status must_== 500
       }
     }
-
-  }
-
-  private def muutosAsJsonWithAuditSession(l: LukuvuosimaksuMuutos) = {
-    val request = LukuvuosimaksuRequest(List(l), auditSession)
-
-    import org.json4s.native.Serialization.write
-    val json = write(request)
-
-    json.getBytes("UTF-8")
-  }
-
-  private def muutosAsJson(l: LukuvuosimaksuMuutos) = {
-    val request = List(l)
-
-    import org.json4s.native.Serialization.write
-    val json = write(request)
-
-    json.getBytes("UTF-8")
   }
 
   step(organisaatioService.stop())
   step(deleteAll())
+
+  private def muutosAsJsonWithAuditSession(l: LukuvuosimaksuMuutos) = {
+    serialiseToJson(LukuvuosimaksuRequest(List(l), auditSession))
+  }
+
+  private def muutosAsJson(l: LukuvuosimaksuMuutos) = serialiseToJson(List(l))
+
+  private def serialiseToJson(request: AnyRef): Array[Byte] = {
+    import org.json4s.native.Serialization.write
+    write(request).getBytes("UTF-8")
+  }
 }

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/LukuvuosimaksuRepository.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/LukuvuosimaksuRepository.scala
@@ -4,5 +4,6 @@ import fi.vm.sade.valintatulosservice.valintarekisteri.domain.{Lukuvuosimaksu,Ha
 
 trait LukuvuosimaksuRepository {
   def getLukuvuosimaksus(hakukohdeOid: HakukohdeOid): List[Lukuvuosimaksu]
+  def getLukuvuosimaksus(hakukohdeOids: Set[HakukohdeOid]): List[Lukuvuosimaksu]
   def update(lukuvuosimaksut: List[Lukuvuosimaksu]): Unit
 }


### PR DESCRIPTION
Yksi mahdollinen hitauden syy on ollut se, että hakukohteen kaikkien hakijoiden kaikkien hakutoiveiden oidit haetaan yhteen ja sitten näille haetaan yksi kerrallaan lukuvuosimaksutiedot.

On parempi hakea koko kyseisen hakukohdeoid-setin tiedot kerralla, koska data määrät ovat joka tapauksessa pieniä (tuotannossa koko kannassa on alle 4000 riviä).