### PR TITLE
BUG-1809  jonojen järjestys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <scalatra_2.11.version>2.5.0</scalatra_2.11.version>
         <scalaz-stream_2.11.version>0.7a</scalaz-stream_2.11.version> <!-- required by specs2 3.5 -->
         <scalaz_2.11.version>7.1.11</scalaz_2.11.version> <!-- latest that works with http4s 0.15.8 -->
-        <sijoittelu.version>6.0.1-SNAPSHOT</sijoittelu.version>
+        <sijoittelu.version>6.1.0-SNAPSHOT</sijoittelu.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
         <slick_2.11.version>3.2.0</slick_2.11.version>
         <specs2_2.11.version>3.8.6-scalaz-7.1</specs2_2.11.version>

--- a/valinta-tulos-service/src/main/resources/fixtures/sijoittelu/hylatty-peruste-viimeisesta-jonosta.json
+++ b/valinta-tulos-service/src/main/resources/fixtures/sijoittelu/hylatty-peruste-viimeisesta-jonosta.json
@@ -49,44 +49,6 @@
       "valintatapajonot": [
         {
           "tasasijasaanto": "YLITAYTTO",
-          "oid": "14090336922663576781797489829886",
-          "nimi": "Varsinainen jono",
-          "prioriteetti": 0,
-          "aloituspaikat": 3,
-          "eiVarasijatayttoa": false,
-          "kaikkiEhdonTayttavatHyvaksytaan": false,
-          "poissaOlevaTaytto": false,
-          "hakemukset": [
-            {
-              "hakijaOid": "1.2.246.562.24.14229104472",
-              "hakemusOid": "1.2.246.562.11.00000441369",
-              "etunimi": "Teppo",
-              "sukunimi": "Testaaja",
-              "prioriteetti": 1,
-              "jonosija": 1,
-              "pisteet": 4,
-              "tasasijaJonosija": 1,
-              "tila": "HYLATTY",
-              "tilaHistoria": [
-                {
-                  "luotu": {
-                    "$date": "2014-08-26T15:12:40.623Z"
-                  },
-                  "tila": "HYLATTY"
-                }
-              ],
-              "hyvaksyttyHarkinnanvaraisesti": false,
-              "tilanKuvaukset": {
-                "FI": "Ensimmäinen jono",
-                "SV": "Ensimmäinen jono sv",
-                "EN": "Ensimmäinen jono en"
-              },
-              "tilankuvauksenTarkenne": "EI_TILANKUVAUKSEN_TARKENNETTA"
-            }
-          ]
-        },
-        {
-          "tasasijasaanto": "YLITAYTTO",
           "oid": "14090336922663576781797489829887",
           "nimi": "Toinen jono",
           "prioriteetti": 1,
@@ -122,6 +84,44 @@
               "tilankuvauksenTarkenne": "EI_TILANKUVAUKSEN_TARKENNETTA"
             }
           ]
+        },
+        {
+          "tasasijasaanto": "YLITAYTTO",
+          "oid": "14090336922663576781797489829886",
+          "nimi": "Varsinainen jono",
+          "prioriteetti": 0,
+          "aloituspaikat": 3,
+          "eiVarasijatayttoa": false,
+          "kaikkiEhdonTayttavatHyvaksytaan": false,
+          "poissaOlevaTaytto": false,
+          "hakemukset": [
+            {
+              "hakijaOid": "1.2.246.562.24.14229104472",
+              "hakemusOid": "1.2.246.562.11.00000441369",
+              "etunimi": "Teppo",
+              "sukunimi": "Testaaja",
+              "prioriteetti": 1,
+              "jonosija": 1,
+              "pisteet": 4,
+              "tasasijaJonosija": 1,
+              "tila": "HYLATTY",
+              "tilaHistoria": [
+                {
+                  "luotu": {
+                    "$date": "2014-08-26T15:12:40.623Z"
+                  },
+                  "tila": "HYLATTY"
+                }
+              ],
+              "hyvaksyttyHarkinnanvaraisesti": false,
+              "tilanKuvaukset": {
+                "FI": "Ensimmäinen jono",
+                "SV": "Ensimmäinen jono sv",
+                "EN": "Ensimmäinen jono en"
+              },
+              "tilankuvauksenTarkenne": "EI_TILANKUVAUKSEN_TARKENNETTA"
+            }
+          ]
         }
       ]
     }
@@ -138,7 +138,7 @@
       "hakijaOid": "1.2.246.562.24.14229104472",
       "hakuOid": "1.2.246.562.5.2013080813081926341928",
       "hakutoive": 1,
-      "tila": "PERUUTETTU",
+      "tila": "KESKEN",
       "ilmoittautumisTila": "EI_TEHTY",
       "julkaistavissa": true,
       "logEntries": [

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
@@ -336,64 +336,39 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
     valintatulokset
   }
 
-  @Deprecated //Ei käytetä/sivutusta ei käytetä
   def sijoittelunTulokset(hakuOid: HakuOid, sijoitteluajoId: String, hyvaksytyt: Option[Boolean], ilmanHyvaksyntaa: Option[Boolean], vastaanottaneet: Option[Boolean],
                           hakukohdeOid: Option[List[HakukohdeOid]], count: Option[Int], index: Option[Int]): HakijaPaginationObject = timed(s"Getting sijoittelun tulokset for haku ${hakuOid}") {
     val haunVastaanototByHakijaOid = timed("Fetch haun vastaanotot for haku: " + hakuOid, 1000) {
       virkailijaVastaanottoRepository.findHaunVastaanotot(hakuOid).groupBy(_.henkiloOid)
     }
-    val hakemustenTulokset = hakemustenTulosByHaku(hakuOid, Some(haunVastaanototByHakijaOid))
-    val hakutoiveidenTuloksetByHakemusOid: Map[HakemusOid, List[Hakutoiveentulos]] = hakemustenTulokset match {
-      case Some(hakemustenTulosIterator) =>
-        /* ValintatulosService:173: `() => hakemusRepository.findHakemukset(hakuOid)`
-         * results are only realized here when the iterator is converted to map!! */
-        timed("Realizing hakemukset mongo calls from hakemuksenTulokset") {hakemustenTulosIterator.map(h => (h.hakemusOid, h.hakutoiveet)).toMap}
-      case None => Map()
+    val hakemustenTulokset = hakukohdeOid match {
+      case Some(oid :: Nil) => hakemustenTulosByHakukohde(hakuOid, oid, Some(haunVastaanototByHakijaOid)).right.get
+      case _ => hakemustenTulosByHaku(hakuOid, Some(haunVastaanototByHakijaOid)).getOrElse(Iterator.empty)
     }
-
-    val personOidsByHakemusOids: Map[HakemusOid, String] = hakukohdeOid match {
-      case Some(oids) => timed("Fetching hakemukset from hakemusRepository for haku and hakukohteet", 1000) (hakemusRepository.findPersonOids(hakuOid, oids))
-      case _ => timed("Fetching hakemukset from hakemusRepository for haku", 1000) (hakemusRepository.findPersonOids(hakuOid))
-    }
-    
-    try {
-      val haku = hakuService.getHaku(hakuOid) match {
-        case Right(h) => h
-        case Left(e) => throw e
+    val hakemustenTuloksetByHakemusOid: Map[HakemusOid, Hakemuksentulos] =
+      timed("Realizing hakemukset mongo calls from hakemuksenTulokset") {
+        hakemustenTulokset.map(h => h.hakemusOid -> h).toMap
       }
+
+    try {
       val hakijaPaginationObject = sijoittelutulosService.sijoittelunTuloksetWithoutVastaanottoTieto(hakuOid, sijoitteluajoId, hyvaksytyt, ilmanHyvaksyntaa, vastaanottaneet,
-        hakukohdeOid, count, index, haunVastaanototByHakijaOid)
-      val hakukohdes: Map[HakukohdeOid, Option[Kausi]] = (hakukohdeRecordService.getHaunHakukohdeRecords(hakuOid) match {
-        case Right(hks) => hks.map(hk => hk.oid -> {if(hk.yhdenPaikanSaantoVoimassa) Some(hk.koulutuksenAlkamiskausi) else None})
-        case Left(e) => throw e
-      }).toMap
-      val uniqueKaudetInHaku: Set[Kausi] = hakukohdes.values.flatten.toSet
-      val kausiToVastaanotto: Map[Kausi, Set[String]] = uniqueKaudetInHaku.map(kausi => kausi ->
-        virkailijaVastaanottoRepository.findkoulutuksenAlkamiskaudenVastaanottaneetYhdenPaikanSaadoksenPiirissa(kausi).map(_.henkiloOid)).toMap
-
-      val hakijat = hakijaPaginationObject.getResults.asScala
-      assertNoMissingHakemusOidsInKeys(hakijat.map(_.getHakemusOid).map(HakemusOid).toSet, personOidsByHakemusOids.keySet)
-
-      hakijat.foreach { hakijaDto =>
-        val hakijaOidFromHakemus = personOidsByHakemusOids(HakemusOid(hakijaDto.getHakemusOid))
-        hakijaDto.setHakijaOid(hakijaOidFromHakemus)
-        val hakijanVastaanotot = haunVastaanototByHakijaOid.get(hakijaDto.getHakijaOid)
-        val hakutoiveidenTulokset = hakutoiveidenTuloksetByHakemusOid.getOrElse(HakemusOid(hakijaDto.getHakemusOid), throw new IllegalArgumentException(s"Hakemusta ${hakijaDto.getHakemusOid} ei löydy"))
-        val yhdenPaikanSannonHuomioiminen = asetaVastaanotettavuusValintarekisterinPerusteella(hakukohdeOid => {
-          hakukohdes.get(hakukohdeOid).flatten.flatMap(kausi => Some(kausi, kausiToVastaanotto.get(kausi).map(_.contains(hakijaDto.getHakijaOid)).getOrElse(false)))
-        })(hakutoiveidenTulokset, haku, None)
-        hakijaDto.getHakutoiveet.asScala.foreach(palautettavaHakutoiveDto =>
-          hakijanVastaanotot match {
-            case Some(vastaanottos) =>
-              vastaanottos.find(_.hakukohdeOid.toString == palautettavaHakutoiveDto.getHakukohdeOid).foreach(vastaanotto => {
-                yhdenPaikanSannonHuomioiminen.find(_.hakukohdeOid.toString == palautettavaHakutoiveDto.getHakukohdeOid).foreach(hakutoiveenOikeaTulos => {
-                  palautettavaHakutoiveDto.setVastaanottotieto(fi.vm.sade.sijoittelu.tulos.dto.ValintatuloksenTila.valueOf(hakutoiveenOikeaTulos.vastaanottotila.toString))
-                  palautettavaHakutoiveDto.getHakutoiveenValintatapajonot.asScala.foreach(_.setTilanKuvaukset(hakutoiveenOikeaTulos.tilanKuvaukset.asJava))
-                })
-              })
-            case None => palautettavaHakutoiveDto.setVastaanottotieto(dto.ValintatuloksenTila.KESKEN)
+        hakukohdeOid, count, index)
+      assertNoMissingHakemusOidsInKeys(
+        hakijaPaginationObject.getResults.asScala.map(h => HakemusOid(h.getHakemusOid)).toSet,
+        hakemustenTuloksetByHakemusOid.keySet
+      )
+      hakijaPaginationObject.getResults.asScala.foreach { hakijaDto =>
+        val hakemuksenTulos = hakemustenTuloksetByHakemusOid(HakemusOid(hakijaDto.getHakemusOid))
+        hakijaDto.setHakijaOid(hakemuksenTulos.hakijaOid)
+        hakijaDto.getHakutoiveet.asScala.foreach(hakutoiveDto => {
+          val tulos = hakemuksenTulos.findHakutoive(HakukohdeOid(hakutoiveDto.getHakukohdeOid)).
+            getOrElse(throw new IllegalStateException(s"Ei löydy hakutoiveelle ${hakutoiveDto.getHakukohdeOid} tulosta hakemukselta ${hakijaDto.getHakemusOid}. " +
+              s"Hakutoive saattaa olla poistettu hakemukselta sijoittelun jälkeen."))._1
+          hakutoiveDto.setVastaanottotieto(fi.vm.sade.sijoittelu.tulos.dto.ValintatuloksenTila.valueOf(tulos.vastaanottotila.toString))
+          if (tulos.julkaistavissa) {
+            hakutoiveDto.getHakutoiveenValintatapajonot.asScala.foreach(_.setTilanKuvaukset(tulos.tilanKuvaukset.asJava))
           }
-        )
+        })
       }
       hakijaPaginationObject
     } catch {
@@ -402,13 +377,15 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
         new HakijaPaginationObject
     }
   }
-  private def assertNoMissingHakemusOidsInKeys(hakemusOids: Set[HakemusOid], keys: Set[HakemusOid]) = {
+
+  private def assertNoMissingHakemusOidsInKeys(hakemusOids: Set[HakemusOid], keys: Set[HakemusOid]): Unit = {
     val missingHakemusOids = hakemusOids.diff(keys)
-    if(!missingHakemusOids.isEmpty) {
-      val missingOidsException = s"HakijaDTOs contained more hakemusOids than in hakukohteeseen hyväksytyt: ${missingHakemusOids}"
+    if (missingHakemusOids.nonEmpty) {
+      val missingOidsException = s"HakijaDTOs contained more hakemusOids than in hakukohteeseen hyväksytyt: $missingHakemusOids"
       throw new RuntimeException(missingOidsException)
     }
   }
+
   def sijoittelunTulosHakemukselle(hakuOid: HakuOid, sijoitteluajoId: String, hakemusOid: HakemusOid): Option[HakijaDTO] = {
     val hakemuksenTulosOption = hakemuksentulos(hakemusOid)
     val hakijaOidFromHakemusOption = hakemusRepository.findHakemus(hakemusOid).right.map(_.henkiloOid)

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/JonoFinder.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/JonoFinder.scala
@@ -23,7 +23,12 @@ object JonoFinder {
       if (tila1 == Valintatila.varalla && tila2 == Valintatila.varalla) {
         jono1.getVarasijanNumero < jono2.getVarasijanNumero
       } else {
-        tila1.compareTo(tila2) < 0
+        val ord = tila1.compareTo(tila2)
+        if(ord == 0) {
+          jono1.getPrioriteetti.compareTo(jono2.getPrioriteetti) < 0
+        } else {
+          ord < 0
+        }
       }
     }
 

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/JonoFinder.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/JonoFinder.scala
@@ -24,7 +24,7 @@ object JonoFinder {
         jono1.getVarasijanNumero < jono2.getVarasijanNumero
       } else {
         val ord = tila1.compareTo(tila2)
-        if(ord == 0) {
+        if (ord == 0 && jono1.getPrioriteetti != null) {
           jono1.getPrioriteetti.compareTo(jono2.getPrioriteetti) < 0
         } else {
           ord < 0
@@ -32,7 +32,14 @@ object JonoFinder {
       }
     }
 
-    val orderedJonot: List[KevytHakutoiveenValintatapajonoDTO] = hakutoive.getHakutoiveenValintatapajonot.toList.sorted(ordering)
+    val jonot = hakutoive.getHakutoiveenValintatapajonot.toList
+    val jonotWithNullPrioriteettiCount: Int = jonot.count(_.getPrioriteetti == null)
+    if (jonotWithNullPrioriteettiCount != 0 && jonotWithNullPrioriteettiCount != jonot.size) {
+      throw new RuntimeException(s"Hakukohteella ${hakutoive.getHakukohdeOid} oli sekä nullin että ei-nullin " +
+        "prioriteetin jonoja. Hakukohteella joko kaikkien tai ei minkään jonojen prioriteettien tulee olla null. " +
+        "Onko sijoittelua käyttäviä ja käyttämättömiä jonoja mennyt sekaisin?")
+    }
+    val orderedJonot: List[KevytHakutoiveenValintatapajonoDTO] = jonot.sorted(ordering)
     val headOption: Option[KevytHakutoiveenValintatapajonoDTO] = orderedJonot.headOption
     headOption.map(jono => {
       val tila: Valintatila = fromHakemuksenTila(jono.getTila)

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/SijoittelutulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/SijoittelutulosService.scala
@@ -104,10 +104,8 @@ class SijoittelutulosService(raportointiService: ValintarekisteriRaportointiServ
     }
   }
 
-  @Deprecated //Ei käytetä/sivutusta ei käytetä
   def sijoittelunTuloksetWithoutVastaanottoTieto(hakuOid: HakuOid, sijoitteluajoId: String, hyvaksytyt: Option[Boolean], ilmanHyvaksyntaa: Option[Boolean], vastaanottaneet: Option[Boolean],
-                                                 hakukohdeOid: Option[List[HakukohdeOid]], count: Option[Int], index: Option[Int],
-                                                 haunVastaanototByHakijaOid: Map[String, Set[VastaanottoRecord]]): HakijaPaginationObject = {
+                                                 hakukohdeOid: Option[List[HakukohdeOid]], count: Option[Int], index: Option[Int]): HakijaPaginationObject = {
 
     val id: Option[Long] = findSijoitteluAjo(hakuOid, sijoitteluajoId)
     raportointiService.hakemukset(id, hakuOid, hyvaksytyt, ilmanHyvaksyntaa, vastaanottaneet, hakukohdeOid, count, index)

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/valintarekisteriRaportointiService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/valintarekisteriRaportointiService.scala
@@ -1,22 +1,19 @@
 package fi.vm.sade.valintatulosservice.sijoittelu
 
-import java.util
 import java.util.Collections.sort
 
-import fi.vm.sade.sijoittelu.domain.{Hakukohde, SijoitteluAjo, Valintatulos}
+import fi.vm.sade.sijoittelu.domain.SijoitteluAjo
 import fi.vm.sade.sijoittelu.tulos.dto.HakemuksenTila.VARASIJALTA_HYVAKSYTTY
 import fi.vm.sade.sijoittelu.tulos.dto.raportointi.{HakijaDTO, HakijaPaginationObject, KevytHakijaDTO}
 import fi.vm.sade.sijoittelu.tulos.dto.{HakemuksenTila, ValintatuloksenTila}
 import fi.vm.sade.sijoittelu.tulos.service.impl.comparators.HakijaDTOComparator
-import fi.vm.sade.sijoittelu.tulos.service.impl.converters.{RaportointiConverterImpl, SijoitteluTulosConverterImpl}
 import fi.vm.sade.utils.Timer.timed
 import fi.vm.sade.utils.slf4j.Logging
 import fi.vm.sade.valintatulosservice.valintarekisteri.db.{HakijaRepository, SijoitteluRepository, ValinnantulosRepository}
-import fi.vm.sade.valintatulosservice.valintarekisteri.domain.{HakemusRecord, HakuOid, HakukohdeOid, _}
-import fi.vm.sade.valintatulosservice.valintarekisteri.sijoittelu.{SijoitteluajonHakijat, SijoitteluajonHakukohteet}
+import fi.vm.sade.valintatulosservice.valintarekisteri.domain.{HakuOid, HakukohdeOid, _}
+import fi.vm.sade.valintatulosservice.valintarekisteri.sijoittelu.SijoitteluajonHakijat
 
 import scala.collection.JavaConverters._
-import fi.vm.sade.valintatulosservice.memoize.TTLOptionalMemoize
 import scala.util.{Failure, Success, Try}
 
 trait ValintarekisteriRaportointiService {

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintaTulosServletSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintaTulosServletSpec.scala
@@ -9,6 +9,7 @@ import fi.vm.sade.valintatulosservice.production.Hakija
 import fi.vm.sade.valintatulosservice.tarjonta.HakuFixtures
 import fi.vm.sade.valintatulosservice.valintarekisteri.domain._
 import org.joda.time.{DateTime, DateTimeZone}
+import org.json4s.native.JsonMethods.{compact, render}
 import org.json4s.JValue
 import org.json4s.JsonAST.JArray
 import org.json4s.jackson.Serialization
@@ -371,6 +372,21 @@ class ValintaTulosServletSpec extends ServletSpecification {
           tulos.hakutoiveet.head.viimeisinValintatuloksenMuutos must beNone
           muutosAika.getTime() must be ~ (System.currentTimeMillis() +/- 2000)
         }
+      }
+    }
+  }
+
+  "GET /haku/:hakuOid/ilmanHyvaksyntaa" should {
+    "palauttaa oikea hylkäyksen syy" in {
+      useFixture("hylatty-peruste-viimeisesta-jonosta.json")
+      val hakuOid = "1.2.246.562.5.2013080813081926341928"
+      get(s"haku/$hakuOid/ilmanHyvaksyntaa") {
+        status must_== 200
+        val streamedJson = JsonMethods.parse(body)
+
+        val result = (((streamedJson \\ "results").asInstanceOf[JArray](0) \\ "hakutoiveet").asInstanceOf[JArray](0) \\ "hakutoiveenValintatapajonot").asInstanceOf[JArray](0) \\ "tilanKuvaukset"
+
+        compact(render(result)) must_== """{"FI":"Toinen jono","SV":"Toinen jono sv","EN":"Toinen jono en"}"""
       }
     }
   }

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/domain/sijoitteluRecords.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/domain/sijoitteluRecords.scala
@@ -155,6 +155,7 @@ case class HakutoiveenValintatapajonoRecord(hakemusOid: HakemusOid, hakukohdeOid
     hakutoiveenValintatapajonoDto.setTilanKuvaukset(tilankuvaukset.asJava)
     hakutoiveenValintatapajonoDto.setHyvaksyttyHarkinnanvaraisesti(hyvaksyttyHarkinnanvaraisesti)
     hakutoiveenValintatapajonoDto.setValintatapajonoOid(valintatapajonoOid.toString)
+    hakutoiveenValintatapajonoDto.setPrioriteetti(valintatapajonoPrioriteetti)
     hakutoiveenValintatapajonoDto
   }
 


### PR DESCRIPTION
Tehty yksikkötesti joka hajoaa kun valintatapajonot eivät järjesty oikein. Vaihdettu jonojen järjestyksessä fikstuurassa niin että järjestys on väärä jos JonoFinderin sorttaus ei sitä oikeaksi korjaa.

Lisätty kevytDTO:hon prioriteetti-kenttä (ks. https://github.com/Opetushallitus/valintaperusteet/pull/228) jota käytetään jonojen sorttaamisessa.