### PR TITLE
OK-221 : hakukohdekohtainen api ulkoisille rajapinnoille

### DIFF
--- a/valinta-tulos-service/src/main/resources/oph-configuration/valinta-tulos-service-devtest.properties.template
+++ b/valinta-tulos-service/src/main/resources/oph-configuration/valinta-tulos-service-devtest.properties.template
@@ -14,6 +14,8 @@ host.alb={{host_alb}}
 valinta-tulos-service.ohjausparametrit.url=https\://{{host_virkailija}}/ohjausparametrit-service/api/v1/rest/parametri
 valinta-tulos-service.ilmoittautuminen.enabled={{valintatulosservice_ilmoittautuminen_enabled}}
 
+valinta-tulos-service.streaming.hakukohde.concurrency={{valintatulosservice_streaming_hakukohde_concurrency | default('10') }}
+
 #SIJOITTELU-SERVICE
 sijoittelu-service.rest.url=https://{{host_virkailija}}/sijoittelu-service
 valinta-tulos-service.parseleniently.sijoitteluajontulos={{valintatulosservice_parseleniently_sijoitteluajontulos}}

--- a/valinta-tulos-service/src/main/resources/oph-configuration/valinta-tulos-service.properties.template
+++ b/valinta-tulos-service/src/main/resources/oph-configuration/valinta-tulos-service.properties.template
@@ -13,6 +13,8 @@ host.alb={{host_alb}}
 valinta-tulos-service.ohjausparametrit.url=https\://{{host_virkailija}}/ohjausparametrit-service/api/v1/rest/parametri
 valinta-tulos-service.ilmoittautuminen.enabled={{valintatulosservice_ilmoittautuminen_enabled}}
 
+valinta-tulos-service.streaming.hakukohde.concurrency={{valintatulosservice_streaming_hakukohde_concurrency | default('10') }}
+
 #SIJOITTELU-SERVICE
 sijoittelu-service.rest.url=https://{{host_virkailija}}/sijoittelu-service
 valinta-tulos-service.parseleniently.sijoitteluajontulos={{valintatulosservice_parseleniently_sijoitteluajontulos}}

--- a/valinta-tulos-service/src/main/scala/ScalatraBootstrap.scala
+++ b/valinta-tulos-service/src/main/scala/ScalatraBootstrap.scala
@@ -78,7 +78,7 @@ class ScalatraBootstrap extends LifeCycle with Logging {
     lazy val ataruHakemusTarjontaEnricher = new AtaruHakemusEnricher(hakuService, oppijanumerorekisteriService)
     lazy val hakemusRepository = new HakemusRepository(hakuAppRepository, ataruHakemusRepository, ataruHakemusTarjontaEnricher)
     lazy val valintatulosService = new ValintatulosService(valintarekisteriDb, vastaanotettavuusService, sijoittelutulosService, hakemusRepository, valintarekisteriDb, hakuService, valintarekisteriDb, hakukohdeRecordService, valintatulosDao, hakijaDTOClient)(appConfig,dynamicAppConfig)
-    lazy val streamingValintatulosService = new StreamingValintatulosService(valintatulosService, valintarekisteriDb, hakijaDTOClient)
+    lazy val streamingValintatulosService = new StreamingValintatulosService(valintatulosService, valintarekisteriDb, hakijaDTOClient)(appConfig)
     lazy val vastaanottoService = new VastaanottoService(hakuService, hakukohdeRecordService, vastaanotettavuusService, valintatulosService, valintarekisteriDb, appConfig.ohjausparametritService, sijoittelutulosService, hakemusRepository, valintarekisteriDb)
     lazy val ilmoittautumisService = new IlmoittautumisService(valintatulosService, valintarekisteriDb, valintarekisteriDb)
     lazy val mailPollerRepository: MailPollerRepository = valintarekisteriDb

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/PrivateValintatulosServlet.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/PrivateValintatulosServlet.scala
@@ -1,10 +1,18 @@
 package fi.vm.sade.valintatulosservice
 
 import fi.vm.sade.valintatulosservice.config.VtsAppConfig.VtsAppConfig
+import fi.vm.sade.valintatulosservice.streamingresults.StreamingValintatulosService
 import fi.vm.sade.valintatulosservice.valintarekisteri.db.impl.ValintarekisteriDb
 import org.scalatra.swagger._
 
-class PrivateValintatulosServlet(valintatulosService: ValintatulosService, vastaanottoService: VastaanottoService, ilmoittautumisService: IlmoittautumisService, valintarekisteriDb: ValintarekisteriDb)(override implicit val swagger: Swagger, appConfig: VtsAppConfig) extends ValintatulosServlet(valintatulosService, vastaanottoService, ilmoittautumisService, valintarekisteriDb)(swagger, appConfig) {
+class PrivateValintatulosServlet(valintatulosService: ValintatulosService,
+                                 streamingValintatulosService: StreamingValintatulosService,
+                                 vastaanottoService: VastaanottoService,
+                                 ilmoittautumisService: IlmoittautumisService,
+                                 valintarekisteriDb: ValintarekisteriDb)
+                                (override implicit val swagger: Swagger,
+                                 appConfig: VtsAppConfig)
+  extends ValintatulosServlet(valintatulosService, streamingValintatulosService, vastaanottoService, ilmoittautumisService, valintarekisteriDb)(swagger, appConfig) {
 
   override val applicationName = Some("haku")
 

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/PublicValintatulosServlet.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/PublicValintatulosServlet.scala
@@ -1,10 +1,18 @@
 package fi.vm.sade.valintatulosservice
 
 import fi.vm.sade.valintatulosservice.config.VtsAppConfig.VtsAppConfig
+import fi.vm.sade.valintatulosservice.streamingresults.StreamingValintatulosService
 import fi.vm.sade.valintatulosservice.valintarekisteri.db.impl.ValintarekisteriDb
 import org.scalatra.swagger._
 
-class PublicValintatulosServlet(valintatulosService: ValintatulosService, vastaanottoService: VastaanottoService, ilmoittautumisService: IlmoittautumisService, valintarekisteriDb: ValintarekisteriDb)(override implicit val swagger: Swagger, appConfig: VtsAppConfig) extends ValintatulosServlet(valintatulosService, vastaanottoService, ilmoittautumisService, valintarekisteriDb)(swagger, appConfig) {
+class PublicValintatulosServlet(valintatulosService: ValintatulosService,
+                                streamingValintatulosService: StreamingValintatulosService,
+                                vastaanottoService: VastaanottoService,
+                                ilmoittautumisService: IlmoittautumisService,
+                                valintarekisteriDb: ValintarekisteriDb)
+                               (override implicit val swagger: Swagger,
+                                appConfig: VtsAppConfig)
+  extends ValintatulosServlet(valintatulosService, streamingValintatulosService, vastaanottoService, ilmoittautumisService, valintarekisteriDb)(swagger, appConfig) {
 
   override val applicationName = Some("cas/haku")
 

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
@@ -534,7 +534,7 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
     Hakemuksentulos(haku.oid, h.oid, sijoitteluTulos.hakijaOid.getOrElse(h.henkiloOid), ohjausparametrit.map(_.vastaanottoaikataulu), lopullisetTulokset)
   }
   private def asetaKelaURL(hakemusOid: HakemusOid, tulokset: List[Hakutoiveentulos], haku: Haku, ohjausparametrit: Option[Ohjausparametrit]): List[Hakutoiveentulos] = {
-    val hakukierrosEiOlePäättynyt = !ohjausparametrit.flatMap(_.hakukierrosPaattyy).map(_.isBefore(DateTime.now())).getOrElse(false)
+    val hakukierrosEiOlePäättynyt = !ohjausparametrit.flatMap(_.hakukierrosPaattyy).exists(_.isBefore(DateTime.now()))
     val näytetäänSiirryKelaanURL = dynamicAppConfig.näytetäänSiirryKelaanURL
     val näytetäänKelaURL = if (hakukierrosEiOlePäättynyt && näytetäänSiirryKelaanURL && haku.sallittuKohdejoukkoKelaLinkille) Some(appConfig.settings.kelaURL) else None
 

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
@@ -173,7 +173,7 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
     }
   }
 
-  private def hakemustenTulosByHaku(hakuOid: HakuOid, haunVastaanotot: Option[Map[String,Set[VastaanottoRecord]]], checkJulkaisuAikaParametri: Boolean = true): Option[Iterator[Hakemuksentulos]] = {
+  def hakemustenTulosByHaku(hakuOid: HakuOid, haunVastaanotot: Option[Map[String,Set[VastaanottoRecord]]], checkJulkaisuAikaParametri: Boolean = true): Option[Iterator[Hakemuksentulos]] = {
     timed("Fetch hakemusten tulos for haku: " + hakuOid, 1000) (
       for {
         haku <- hakuService.getHaku(hakuOid).right.toOption
@@ -399,107 +399,18 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
     })
   }
 
-  def streamSijoittelunTulokset(hakuOid: HakuOid,
-                                sijoitteluajoId: String,
-                                hakukohdeOids: Set[HakukohdeOid],
-                                writeResult: HakijaDTO => Unit,
-                                vainMerkitsevaJono : Boolean): Unit = {
-    val haunVastaanototByHakijaOid = timed("Fetch haun vastaanotot for haku: " + hakuOid, 1000) {
-      virkailijaVastaanottoRepository.findHaunVastaanotot(hakuOid).groupBy(_.henkiloOid)
-    }
-    val hakemustenTulokset: Option[Iterator[Hakemuksentulos]] = Some(hakukohdeOids.map { hakukohdeOid =>
-      hakemustenTulosByHakukohde(hakuOid, hakukohdeOid, Some(haunVastaanototByHakijaOid)) match {
-        case Right(it) => it
-        case Left(e) => val msg = s"Could not retrieve results for hakukohde $hakukohdeOid of haku $hakuOid"
-          logger.error(msg)
-          throw new RuntimeException(msg)
-      }
-    }.reduce((i1, i2) => i1 ++ i2))
-    val hakutoiveidenTuloksetByHakemusOid: Map[HakemusOid, (String, List[Hakutoiveentulos])] =
-      timed(s"Find hakutoiveiden tulokset for ${hakukohdeOids.size} hakukohdes of haku $hakuOid", 1000) {
-        hakemustenTulokset match {
-          case Some(hakemustenTulosIterator) => hakemustenTulosIterator.map(h => (h.hakemusOid, (h.hakijaOid, h.hakutoiveet))).toMap
-          case None => Map()
-        }
-      }
-    logger.info(s"Found ${hakutoiveidenTuloksetByHakemusOid.keySet.size} hakemus objects for sijoitteluajo $sijoitteluajoId " +
-      s"of ${hakukohdeOids.size} hakukohdes of haku $hakuOid")
-
-    streamSijoittelunTulokset(hakutoiveidenTuloksetByHakemusOid, hakuOid, sijoitteluajoId, writeResult, vainMerkitsevaJono)
-  }
-
-
-  def streamSijoittelunTulokset(hakuOid: HakuOid, sijoitteluajoId: String, writeResult: HakijaDTO => Unit, vainMerkitsevaJono : Boolean): Unit = {
-    val haunVastaanototByHakijaOid = timed("Fetch haun vastaanotot for haku: " + hakuOid, 1000) {
-      virkailijaVastaanottoRepository.findHaunVastaanotot(hakuOid).groupBy(_.henkiloOid)
-    }
-    val hakemustenTulokset: Option[Iterator[Hakemuksentulos]] = hakemustenTulosByHaku(hakuOid, Some(haunVastaanototByHakijaOid))
-    val hakutoiveidenTuloksetByHakemusOid: Map[HakemusOid, (String, List[Hakutoiveentulos])] = timed(s"Find hakutoiveiden tulokset for haku $hakuOid", 1000) {
-      hakemustenTulokset match {
-        case Some(hakemustenTulosIterator) => hakemustenTulosIterator.map(h => (h.hakemusOid, (h.hakijaOid, h.hakutoiveet))).toMap
-        case None => Map()
-      }
-    }
-    logger.info(s"Found ${hakutoiveidenTuloksetByHakemusOid.keySet.size} hakemus objects for sijoitteluajo $sijoitteluajoId of haku $hakuOid")
-
-    streamSijoittelunTulokset(hakutoiveidenTuloksetByHakemusOid, hakuOid, sijoitteluajoId, writeResult, vainMerkitsevaJono)
-  }
-
-  private def streamSijoittelunTulokset(tuloksetByHakemusOid: Map[HakemusOid, (String, List[Hakutoiveentulos])],
-                                        hakuOid: HakuOid,
-                                        sijoitteluajoId: String,
-                                        writeResult: HakijaDTO => Unit,
-                                        vainMerkitsevaJono: Boolean): Unit = {
-    def processTulos(hakijaDto: HakijaDTO, hakijaOid: String, hakutoiveidenTulokset: List[Hakutoiveentulos]): Unit = {
-      hakijaDto.setHakijaOid(hakijaOid)
-      if (vainMerkitsevaJono) {
-        populateMerkitsevatJonot(hakijaDto, hakutoiveidenTulokset)
-      } else {
-        populateVastaanottotieto(hakijaDto, hakutoiveidenTulokset)
-      }
-      writeResult(hakijaDto)
-    }
-
-    try {
-      hakijaDTOClient.processSijoittelunTulokset(hakuOid, sijoitteluajoId, { hakijaDto: HakijaDTO =>
-        tuloksetByHakemusOid.get(HakemusOid(hakijaDto.getHakemusOid)) match {
-          case Some((hakijaOid, hakutoiveidenTulokset)) => processTulos(hakijaDto, hakijaOid, hakutoiveidenTulokset)
-          case None => crashOrLog(s"Hakemus ${hakijaDto.getHakemusOid} not found in hakemusten tulokset for haku $hakuOid")
-        }
-      })
-    } catch {
-      case e: Exception =>
-        logger.error(s"Sijoitteluajon $sijoitteluajoId hakemuksia ei saatu palautettua haulle $hakuOid", e)
-        throw e
-    }
-  }
-
-  private def copyVastaanottotieto(hakutoiveDto: HakutoiveDTO, hakutoiveenTulos: Hakutoiveentulos) = {
+  def copyVastaanottotieto(hakutoiveDto: HakutoiveDTO, hakutoiveenTulos: Hakutoiveentulos) = {
     hakutoiveDto.setVastaanottotieto(fi.vm.sade.sijoittelu.tulos.dto.ValintatuloksenTila.valueOf(hakutoiveenTulos.vastaanottotila.toString))
     hakutoiveDto.getHakutoiveenValintatapajonot.asScala.foreach(_.setTilanKuvaukset(hakutoiveenTulos.tilanKuvaukset.asJava))
   }
 
-  private def populateVastaanottotieto(hakijaDto: HakijaDTO, hakemuksenHakutoiveidenTuloksetVastaanottotiedonKanssa: List[Hakutoiveentulos]): Unit = {
+  def populateVastaanottotieto(hakijaDto: HakijaDTO, hakemuksenHakutoiveidenTuloksetVastaanottotiedonKanssa: List[Hakutoiveentulos]): Unit = {
     hakijaDto.getHakutoiveet.asScala.foreach(palautettavaHakutoiveDto =>
       hakemuksenHakutoiveidenTuloksetVastaanottotiedonKanssa.find(_.hakukohdeOid.toString == palautettavaHakutoiveDto.getHakukohdeOid) match {
         case Some(hakutoiveenOikeaTulos) => copyVastaanottotieto(palautettavaHakutoiveDto, hakutoiveenOikeaTulos)
         case None => palautettavaHakutoiveDto.setVastaanottotieto(dto.ValintatuloksenTila.KESKEN)
       }
     )
-  }
-
-  private def populateMerkitsevatJonot(hakijaDto: HakijaDTO, hakemuksenHakutoiveidenTuloksetVastaanottotiedonKanssa: List[Hakutoiveentulos]) = {
-    hakijaDto.getHakutoiveet.asScala.foreach(hakutoiveDto => {
-      hakemuksenHakutoiveidenTuloksetVastaanottotiedonKanssa.find(_.hakukohdeOid.toString == hakutoiveDto.getHakukohdeOid) match {
-        case Some(hakutoiveenTulos: Hakutoiveentulos) => {
-          hakutoiveDto.setHakutoiveenValintatapajonot(
-            hakutoiveDto.getHakutoiveenValintatapajonot.asScala.filter(_.getValintatapajonoOid == hakutoiveenTulos.valintatapajonoOid.toString).asJava
-          )
-          copyVastaanottotieto(hakutoiveDto, hakutoiveenTulos)
-        }
-        case None => hakutoiveDto.setHakutoiveenValintatapajonot(List().asJava)
-      }
-    })
   }
 
   private def mapHakemustenTuloksetByHakemusOid(hakemustenTulokset:Iterator[Hakemuksentulos]):Map[HakemusOid, Hakemuksentulos] = {
@@ -890,7 +801,7 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
     }
   }
 
-  private def crashOrLog[T](msg: String): Option[T] = {
+  def crashOrLog[T](msg: String): Option[T] = {
     if (appConfig.settings.lenientSijoitteluntuloksetParsing) {
       logger.warn(msg)
       None

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
@@ -115,9 +115,6 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
     hakemustenTulosByHaku(hakuOid, Some(haunVastaanotot), checkJulkaisuAikaParametri)
   }
 
-  private def hakukohdeRecordToHakutoiveenKausi(hakukohdes: Seq[HakukohdeRecord])(oid: String): Option[Kausi] = {
-    hakukohdes.find(_.oid == oid).filter(_.yhdenPaikanSaantoVoimassa).map(_.koulutuksenAlkamiskausi)
-  }
   def haeTilatHakijoille(hakuOid: HakuOid, hakukohdeOid: HakukohdeOid, valintatapajonoOid: ValintatapajonoOid, hakemusOids: Set[HakemusOid]): Set[TilaHakijalle] = {
     val hakemukset: Seq[Hakemus] = hakemusRepository.findHakemuksetByOids(hakemusOids).toSeq
     val uniqueHakukohdeOids: Seq[HakukohdeOid] = hakemukset.flatMap(_.toiveet.map(_.oid)).distinct

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosServlet.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosServlet.scala
@@ -8,6 +8,7 @@ import fi.vm.sade.valintatulosservice.config.VtsAppConfig.VtsAppConfig
 import fi.vm.sade.valintatulosservice.domain._
 import fi.vm.sade.valintatulosservice.json.{JsonFormats, JsonStreamWriter, StreamingFailureException}
 import fi.vm.sade.valintatulosservice.ohjausparametrit.Ohjausparametrit
+import fi.vm.sade.valintatulosservice.streamingresults.StreamingValintatulosService
 import fi.vm.sade.valintatulosservice.tarjonta.{Haku, Hakuaika, YhdenPaikanSaanto}
 import fi.vm.sade.valintatulosservice.valintarekisteri.db.impl.ValintarekisteriDb
 import fi.vm.sade.valintatulosservice.valintarekisteri.domain._
@@ -21,6 +22,7 @@ import org.scalatra.swagger._
 import scala.util.Try
 
 abstract class ValintatulosServlet(valintatulosService: ValintatulosService,
+                                   streamingValintatulosService: StreamingValintatulosService,
                                    vastaanottoService: VastaanottoService,
                                    ilmoittautumisService: IlmoittautumisService,
                                    valintarekisteriDb: ValintarekisteriDb)
@@ -228,7 +230,7 @@ abstract class ValintatulosServlet(valintatulosService: ValintatulosService,
     val vainMerkitsevaJono = params.get("vainMerkitsevaJono").map(_.toBoolean).getOrElse(false)
 
     writeSijoittelunTuloksetStreamingToResponse(
-      response, hakuOid, w => valintatulosService.streamSijoittelunTulokset(hakuOid, sijoitteluajoId, w, vainMerkitsevaJono))
+      response, hakuOid, w => streamingValintatulosService.streamSijoittelunTulokset(hakuOid, sijoitteluajoId, w, vainMerkitsevaJono))
   }
 
   lazy val postStreamingHaunSijoitteluajonHakukohteidenTuloksetSwagger: OperationBuilder = (apiOperation[Unit]("postStreamingHaunSijoitteluajonHakukohteidenTuloksetSwagger")
@@ -246,7 +248,7 @@ abstract class ValintatulosServlet(valintatulosService: ValintatulosService,
     if (hakukohdeOids.isEmpty) {
       BadRequest(body = Map("error" -> "Anna kysyttävät hakukohdeoidit bodyssä."), reason = "Could not read hakukohde oids from request body.")
     } else {
-      writeSijoittelunTuloksetStreamingToResponse(response, hakuOid, w => valintatulosService.streamSijoittelunTulokset(
+      writeSijoittelunTuloksetStreamingToResponse(response, hakuOid, w => streamingValintatulosService.streamSijoittelunTulokset(
         hakuOid, sijoitteluajoId, hakukohdeOids.toSet.map(HakukohdeOid), w, vainMerkitsevaJono))
     }
   }

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosServlet.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosServlet.scala
@@ -230,7 +230,7 @@ abstract class ValintatulosServlet(valintatulosService: ValintatulosService,
     val vainMerkitsevaJono = params.get("vainMerkitsevaJono").map(_.toBoolean).getOrElse(false)
 
     writeSijoittelunTuloksetStreamingToResponse(
-      response, hakuOid, w => streamingValintatulosService.streamSijoittelunTulokset(hakuOid, sijoitteluajoId, w, vainMerkitsevaJono))
+      response, hakuOid, w => streamingValintatulosService.streamSijoittelunTuloksetOfWholeHaku(hakuOid, sijoitteluajoId, w, vainMerkitsevaJono))
   }
 
   lazy val postStreamingHaunSijoitteluajonHakukohteidenTuloksetSwagger: OperationBuilder = (apiOperation[Unit]("postStreamingHaunSijoitteluajonHakukohteidenTuloksetSwagger")
@@ -248,7 +248,7 @@ abstract class ValintatulosServlet(valintatulosService: ValintatulosService,
     if (hakukohdeOids.isEmpty) {
       BadRequest(body = Map("error" -> "Anna kysyttävät hakukohdeoidit bodyssä."), reason = "Could not read hakukohde oids from request body.")
     } else {
-      writeSijoittelunTuloksetStreamingToResponse(response, hakuOid, w => streamingValintatulosService.streamSijoittelunTulokset(
+      writeSijoittelunTuloksetStreamingToResponse(response, hakuOid, w => streamingValintatulosService.streamSijoittelunTuloksetOfHakukohdes(
         hakuOid, sijoitteluajoId, hakukohdeOids.toSet.map(HakukohdeOid), w, vainMerkitsevaJono))
     }
   }

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosServlet.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosServlet.scala
@@ -20,7 +20,12 @@ import org.scalatra.swagger._
 
 import scala.util.Try
 
-abstract class ValintatulosServlet(valintatulosService: ValintatulosService, vastaanottoService: VastaanottoService, ilmoittautumisService: IlmoittautumisService, valintarekisteriDb: ValintarekisteriDb)(implicit val swagger: Swagger, appConfig: VtsAppConfig) extends VtsServletBase {
+abstract class ValintatulosServlet(valintatulosService: ValintatulosService,
+                                   vastaanottoService: VastaanottoService,
+                                   ilmoittautumisService: IlmoittautumisService,
+                                   valintarekisteriDb: ValintarekisteriDb)
+                                  (implicit val swagger: Swagger,
+                                   appConfig: VtsAppConfig) extends VtsServletBase {
   val ilmoittautumisenAikaleima: Option[Date] = Option(new Date())
   lazy val exampleHakemuksenTulos = Hakemuksentulos(
     HakuOid("2.2.2.2"),

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/config/VtsApplicationSettings.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/config/VtsApplicationSettings.scala
@@ -39,6 +39,7 @@ case class VtsApplicationSettings(config: Config) extends ApplicationSettings(co
   val mailPollerConcurrency: Int = withConfig(_.getInt("valinta-tulos-service.mail-poller.concurrency"))
   val mailPollerResultlessHakukohdeRecheckInterval: Duration = Duration(withConfig(
     _.getInt("valinta-tulos-service.mail-poller.resultless.hakukohde.hours")), HOURS)
+  val hakukohdeStreamingConcurrency: Int = withConfig(_.getInt("valinta-tulos-service.streaming.hakukohde.concurrency"))
 }
 
 object VtsApplicationSettingsParser extends fi.vm.sade.utils.config.ApplicationSettingsParser[VtsApplicationSettings] {

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/valintarekisteriHakijaDTOClient.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/valintarekisteriHakijaDTOClient.scala
@@ -2,28 +2,35 @@ package fi.vm.sade.valintatulosservice.sijoittelu
 
 import fi.vm.sade.sijoittelu.tulos.dto.raportointi.HakijaDTO
 import fi.vm.sade.valintatulosservice.valintarekisteri.db.{SijoitteluRepository, ValinnantulosRepository}
-import fi.vm.sade.valintatulosservice.valintarekisteri.domain.{HakuOid, SyntheticSijoitteluAjoForHakusWithoutSijoittelu}
+import fi.vm.sade.valintatulosservice.valintarekisteri.domain.{HakuOid, HakukohdeOid, SyntheticSijoitteluAjoForHakusWithoutSijoittelu}
 
 import scala.collection.JavaConverters._
 
+case class HakijaDTOSearchCriteria(hakuOid: HakuOid, sijoitteluajoId: String, hakukohdeOids: Option[Set[HakukohdeOid]] = None)
+
 trait ValintarekisteriHakijaDTOClient {
-  def processSijoittelunTulokset[T](hakuOid: HakuOid, sijoitteluajoId: String, processor: HakijaDTO => T)
+  def processSijoittelunTulokset[T](hakijaDTOSearchCriteria: HakijaDTOSearchCriteria, processor: HakijaDTO => T)
 }
 
 class ValintarekisteriHakijaDTOClientImpl(raportointiService: ValintarekisteriRaportointiService,
                                           sijoittelunTulosClient: ValintarekisteriSijoittelunTulosClient,
                                           repository: SijoitteluRepository with ValinnantulosRepository) extends ValintarekisteriHakijaDTOClient {
 
-  override def processSijoittelunTulokset[T](hakuOid: HakuOid, sijoitteluajoId: String, processor: (HakijaDTO) => T) = {
+  override def processSijoittelunTulokset[T](criteria: HakijaDTOSearchCriteria, processor: (HakijaDTO) => T): Unit = {
 
-    (sijoitteluajoId match {
-      case x if repository.isLatest(x) => sijoittelunTulosClient.fetchLatestSijoitteluAjo(hakuOid)
+    (criteria.sijoitteluajoId match {
+      case x if repository.isLatest(x) => sijoittelunTulosClient.fetchLatestSijoitteluAjo(criteria.hakuOid)
       case x => repository.parseId(x).flatMap {
         case id if 0 < id => raportointiService.getSijoitteluAjo(id)
-        case _ => Some(SyntheticSijoitteluAjoForHakusWithoutSijoittelu(hakuOid))
+        case _ => Some(SyntheticSijoitteluAjoForHakusWithoutSijoittelu(criteria.hakuOid))
       }
     }) foreach { sijoitteluajo =>
-      raportointiService.hakemukset(sijoitteluajo).getResults.asScala.foreach(processor)
+      criteria match {
+        case HakijaDTOSearchCriteria(_, _, None) =>
+          raportointiService.hakemukset(sijoitteluajo).getResults.asScala.foreach(processor)
+        case HakijaDTOSearchCriteria(_, _, Some(hakukohdeOids)) =>
+          raportointiService.hakemukset(sijoitteluajo, hakukohdeOids).getResults.asScala.foreach(processor)
+      }
     }
   }
 }

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/valintarekisteriRaportointiService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/valintarekisteriRaportointiService.scala
@@ -25,6 +25,8 @@ trait ValintarekisteriRaportointiService {
 
   def hakemukset(sijoitteluAjo: SijoitteluAjo):HakijaPaginationObject
 
+  def hakemukset(sijoitteluAjo: SijoitteluAjo, hakukohdeOids: Set[HakukohdeOid]):HakijaPaginationObject
+
   //TODO sivutuksen (count/index) voi poistaa?
   def hakemukset(sijoitteluajoId: Option[Long],
                  hakuOid: HakuOid,
@@ -46,8 +48,19 @@ class ValintarekisteriRaportointiServiceImpl(repository: HakijaRepository with S
     case Success(r) => r
   }
 
-  override def hakemukset(sijoitteluAjo: SijoitteluAjo) = {
+  override def hakemukset(sijoitteluAjo: SijoitteluAjo): HakijaPaginationObject = {
     hakemukset(SyntheticSijoitteluAjoForHakusWithoutSijoittelu.getSijoitteluajoId(sijoitteluAjo), HakuOid(sijoitteluAjo.getHakuOid), None, None, None, None, None, None)
+  }
+
+  override def hakemukset(sijoitteluAjo: SijoitteluAjo, hakukohdeOids: Set[HakukohdeOid]): HakijaPaginationObject = {
+    hakemukset(SyntheticSijoitteluAjoForHakusWithoutSijoittelu.getSijoitteluajoId(sijoitteluAjo),
+      HakuOid(sijoitteluAjo.getHakuOid),
+      hyvaksytyt = None,
+      ilmanHyvaksyntaa = None,
+      vastaanottaneet = None,
+      hakukohdeOids = Some(hakukohdeOids.toList),
+      count = None,
+      index = None)
   }
 
   //TODO sivutuksen (count/index) voi poistaa?

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/valintarekisteriRaportointiService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/valintarekisteriRaportointiService.scala
@@ -74,7 +74,7 @@ class ValintarekisteriRaportointiServiceImpl(repository: HakijaRepository with S
                           index: Option[Int]): HakijaPaginationObject = timed("RaportointiService.hakemukset", 1000) {
 
     val hakijat:List[HakijaDTO] = if(hakukohdeOids.isDefined && 0 != hakukohdeOids.get.size) {
-      hakukohdeOids.get.map(SijoitteluajonHakijat.dto(repository, sijoitteluajoId, hakuOid, _)).flatten
+      hakukohdeOids.get.flatMap(SijoitteluajonHakijat.dto(repository, sijoitteluajoId, hakuOid, _))
     } else {
       SijoitteluajonHakijat.dto(repository, sijoitteluajoId, hakuOid)
     }

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/streamingresults/StreamingValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/streamingresults/StreamingValintatulosService.scala
@@ -60,7 +60,10 @@ class StreamingValintatulosService(valintatulosService: ValintatulosService,
   }
 
 
-  def streamSijoittelunTuloksetOfWholeHaku(hakuOid: HakuOid, sijoitteluajoId: String, writeResult: HakijaDTO => Unit, vainMerkitsevaJono : Boolean): Unit = {
+  def streamSijoittelunTuloksetOfWholeHaku(hakuOid: HakuOid,
+                                           sijoitteluajoId: String,
+                                           writeResult: HakijaDTO => Unit,
+                                           vainMerkitsevaJono : Boolean): Unit = {
     val haunVastaanototByHakijaOid = timed("Fetch haun vastaanotot for haku: " + hakuOid, 1000) {
       virkailijaVastaanottoRepository.findHaunVastaanotot(hakuOid).groupBy(_.henkiloOid)
     }

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/streamingresults/StreamingValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/streamingresults/StreamingValintatulosService.scala
@@ -1,0 +1,106 @@
+package fi.vm.sade.valintatulosservice.streamingresults
+
+import fi.vm.sade.sijoittelu.tulos.dto.raportointi.HakijaDTO
+import fi.vm.sade.utils.Timer.timed
+import fi.vm.sade.utils.slf4j.Logging
+import fi.vm.sade.valintatulosservice.ValintatulosService
+import fi.vm.sade.valintatulosservice.domain._
+import fi.vm.sade.valintatulosservice.sijoittelu.ValintarekisteriHakijaDTOClient
+import fi.vm.sade.valintatulosservice.valintarekisteri.db.VirkailijaVastaanottoRepository
+import fi.vm.sade.valintatulosservice.valintarekisteri.domain._
+import scala.collection.JavaConverters._
+
+private object HakemustenTulosHakuLock
+
+class StreamingValintatulosService(valintatulosService: ValintatulosService,
+                                   virkailijaVastaanottoRepository: VirkailijaVastaanottoRepository,
+                                   hakijaDTOClient: ValintarekisteriHakijaDTOClient) extends Logging {
+
+  def streamSijoittelunTulokset(hakuOid: HakuOid,
+                                sijoitteluajoId: String,
+                                hakukohdeOids: Set[HakukohdeOid],
+                                writeResult: HakijaDTO => Unit,
+                                vainMerkitsevaJono : Boolean): Unit = {
+    val haunVastaanototByHakijaOid = timed("Fetch haun vastaanotot for haku: " + hakuOid, 1000) {
+      virkailijaVastaanottoRepository.findHaunVastaanotot(hakuOid).groupBy(_.henkiloOid)
+    }
+    val hakemustenTulokset: Option[Iterator[Hakemuksentulos]] = Some(hakukohdeOids.map { hakukohdeOid =>
+      valintatulosService.hakemustenTulosByHakukohde(hakuOid, hakukohdeOid, Some(haunVastaanototByHakijaOid)) match {
+        case Right(it) => it
+        case Left(e) => val msg = s"Could not retrieve results for hakukohde $hakukohdeOid of haku $hakuOid"
+          logger.error(msg, e)
+          throw new RuntimeException(msg)
+      }
+    }.reduce((i1, i2) => i1 ++ i2))
+    val hakutoiveidenTuloksetByHakemusOid: Map[HakemusOid, (String, List[Hakutoiveentulos])] =
+      timed(s"Find hakutoiveiden tulokset for ${hakukohdeOids.size} hakukohdes of haku $hakuOid", 1000) {
+        hakemustenTulokset match {
+          case Some(hakemustenTulosIterator) => hakemustenTulosIterator.map(h => (h.hakemusOid, (h.hakijaOid, h.hakutoiveet))).toMap
+          case None => Map()
+        }
+      }
+    logger.info(s"Found ${hakutoiveidenTuloksetByHakemusOid.keySet.size} hakemus objects for sijoitteluajo $sijoitteluajoId " +
+      s"of ${hakukohdeOids.size} hakukohdes of haku $hakuOid")
+
+    streamSijoittelunTulokset(hakutoiveidenTuloksetByHakemusOid, hakuOid, sijoitteluajoId, writeResult, vainMerkitsevaJono)
+  }
+
+
+  def streamSijoittelunTulokset(hakuOid: HakuOid, sijoitteluajoId: String, writeResult: HakijaDTO => Unit, vainMerkitsevaJono : Boolean): Unit = {
+    val haunVastaanototByHakijaOid = timed("Fetch haun vastaanotot for haku: " + hakuOid, 1000) {
+      virkailijaVastaanottoRepository.findHaunVastaanotot(hakuOid).groupBy(_.henkiloOid)
+    }
+    val hakemustenTulokset: Option[Iterator[Hakemuksentulos]] = valintatulosService.hakemustenTulosByHaku(hakuOid, Some(haunVastaanototByHakijaOid))
+    val hakutoiveidenTuloksetByHakemusOid: Map[HakemusOid, (String, List[Hakutoiveentulos])] = timed(s"Find hakutoiveiden tulokset for haku $hakuOid", 1000) {
+      hakemustenTulokset match {
+        case Some(hakemustenTulosIterator) => hakemustenTulosIterator.map(h => (h.hakemusOid, (h.hakijaOid, h.hakutoiveet))).toMap
+        case None => Map()
+      }
+    }
+    logger.info(s"Found ${hakutoiveidenTuloksetByHakemusOid.keySet.size} hakemus objects for sijoitteluajo $sijoitteluajoId of haku $hakuOid")
+
+    streamSijoittelunTulokset(hakutoiveidenTuloksetByHakemusOid, hakuOid, sijoitteluajoId, writeResult, vainMerkitsevaJono)
+  }
+
+  private def streamSijoittelunTulokset(tuloksetByHakemusOid: Map[HakemusOid, (String, List[Hakutoiveentulos])],
+                                        hakuOid: HakuOid,
+                                        sijoitteluajoId: String,
+                                        writeResult: HakijaDTO => Unit,
+                                        vainMerkitsevaJono: Boolean): Unit = {
+    def processTulos(hakijaDto: HakijaDTO, hakijaOid: String, hakutoiveidenTulokset: List[Hakutoiveentulos]): Unit = {
+      hakijaDto.setHakijaOid(hakijaOid)
+      if (vainMerkitsevaJono) {
+        populateMerkitsevatJonot(hakijaDto, hakutoiveidenTulokset)
+      } else {
+        valintatulosService.populateVastaanottotieto(hakijaDto, hakutoiveidenTulokset)
+      }
+      writeResult(hakijaDto)
+    }
+
+    try {
+      hakijaDTOClient.processSijoittelunTulokset(hakuOid, sijoitteluajoId, { hakijaDto: HakijaDTO =>
+        tuloksetByHakemusOid.get(HakemusOid(hakijaDto.getHakemusOid)) match {
+          case Some((hakijaOid, hakutoiveidenTulokset)) => processTulos(hakijaDto, hakijaOid, hakutoiveidenTulokset)
+          case None => valintatulosService.crashOrLog(s"Hakemus ${hakijaDto.getHakemusOid} not found in hakemusten tulokset for haku $hakuOid")
+        }
+      })
+    } catch {
+      case e: Exception =>
+        logger.error(s"Sijoitteluajon $sijoitteluajoId hakemuksia ei saatu palautettua haulle $hakuOid", e)
+        throw e
+    }
+  }
+
+  private def populateMerkitsevatJonot(hakijaDto: HakijaDTO, hakemuksenHakutoiveidenTuloksetVastaanottotiedonKanssa: List[Hakutoiveentulos]): Unit = {
+    hakijaDto.getHakutoiveet.asScala.foreach(hakutoiveDto => {
+      hakemuksenHakutoiveidenTuloksetVastaanottotiedonKanssa.find(_.hakukohdeOid.toString == hakutoiveDto.getHakukohdeOid) match {
+        case Some(hakutoiveenTulos: Hakutoiveentulos) =>
+          hakutoiveDto.setHakutoiveenValintatapajonot(
+            hakutoiveDto.getHakutoiveenValintatapajonot.asScala.filter(_.getValintatapajonoOid == hakutoiveenTulos.valintatapajonoOid.toString).asJava
+          )
+          valintatulosService.copyVastaanottotieto(hakutoiveDto, hakutoiveenTulos)
+        case None => hakutoiveDto.setHakutoiveenValintatapajonot(List().asJava)
+      }
+    })
+  }
+}

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/streamingresults/StreamingValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/streamingresults/StreamingValintatulosService.scala
@@ -24,11 +24,11 @@ class StreamingValintatulosService(valintatulosService: ValintatulosService,
 
   logger.info(s"Processing hakukohde results with parallelism of ${taskSupport.environment.getParallelism}")
 
-  def streamSijoittelunTulokset(hakuOid: HakuOid,
-                                sijoitteluajoId: String,
-                                hakukohdeOids: Set[HakukohdeOid],
-                                writeResult: HakijaDTO => Unit,
-                                vainMerkitsevaJono : Boolean): Unit = {
+  def streamSijoittelunTuloksetOfHakukohdes(hakuOid: HakuOid,
+                                            sijoitteluajoId: String,
+                                            hakukohdeOids: Set[HakukohdeOid],
+                                            writeResult: HakijaDTO => Unit,
+                                            vainMerkitsevaJono : Boolean): Unit = {
     val haunVastaanototByHakijaOid = timed("Fetch haun vastaanotot for haku: " + hakuOid, 1000) {
       virkailijaVastaanottoRepository.findHaunVastaanotot(hakuOid).groupBy(_.henkiloOid)
     }
@@ -60,7 +60,7 @@ class StreamingValintatulosService(valintatulosService: ValintatulosService,
   }
 
 
-  def streamSijoittelunTulokset(hakuOid: HakuOid, sijoitteluajoId: String, writeResult: HakijaDTO => Unit, vainMerkitsevaJono : Boolean): Unit = {
+  def streamSijoittelunTuloksetOfWholeHaku(hakuOid: HakuOid, sijoitteluajoId: String, writeResult: HakijaDTO => Unit, vainMerkitsevaJono : Boolean): Unit = {
     val haunVastaanototByHakijaOid = timed("Fetch haun vastaanotot for haku: " + hakuOid, 1000) {
       virkailijaVastaanottoRepository.findHaunVastaanotot(hakuOid).groupBy(_.henkiloOid)
     }

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintaTulosServletSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintaTulosServletSpec.scala
@@ -212,7 +212,6 @@ class ValintaTulosServletSpec extends ServletSpecification {
       vastaanota("VastaanotaSitovasti") {
         get("haku/streaming/1.2.246.562.5.2013080813081926341928/sijoitteluajo/latest/hakemukset") {
           val streamedJson = JsonMethods.parse(body)
-          println("BO DY: " + body)
           stringInJson(streamedJson, "hakijaOid") must_== "1.2.246.562.24.14229104472"
           stringInJson(streamedJson, "hakemusOid") must_== "1.2.246.562.11.00000441369"
           stringInJson(streamedJson, "vastaanottotieto") must_== "VASTAANOTTANUT_SITOVASTI"
@@ -235,7 +234,6 @@ class ValintaTulosServletSpec extends ServletSpecification {
       vastaanota("VastaanotaSitovasti") {
         get("haku/streaming/1.2.246.562.5.2013080813081926341928/sijoitteluajo/latest/hakemukset?vainMerkitsevaJono=true") {
           val streamedJson = JsonMethods.parse(body)
-          println("BO DY: " + body)
           stringInJson(streamedJson, "hakijaOid") must_== "1.2.246.562.24.14229104472"
           stringInJson(streamedJson, "hakemusOid") must_== "1.2.246.562.11.00000441369"
           stringInJson(streamedJson, "vastaanottotieto") must_== "VASTAANOTTANUT_SITOVASTI"
@@ -255,7 +253,6 @@ class ValintaTulosServletSpec extends ServletSpecification {
 
       get("haku/streaming/1.2.246.562.5.2013080813081926341928/sijoitteluajo/latest/hakemukset?vainMerkitsevaJono=true") {
         val streamedJson = JsonMethods.parse(body)
-        println("BO DY: " + body)
         stringInJson(streamedJson, "hakijaOid") must_== "1.2.246.562.24.14229104472"
         stringInJson(streamedJson, "hakemusOid") must_== "1.2.246.562.11.00000441369"
         stringInJson(streamedJson, "vastaanottotieto") must_== "KESKEN"
@@ -278,7 +275,6 @@ class ValintaTulosServletSpec extends ServletSpecification {
           hakukohdeOidsInPostBody,
           headers = Map("Content-type" -> "application/json")) {
             val streamedJson = JsonMethods.parse(body)
-            println("BO DY: " + body)
             stringInJson(streamedJson, "hakijaOid") must_== "1.2.246.562.24.14229104472"
             stringInJson(streamedJson, "hakemusOid") must_== "1.2.246.562.11.00000441369"
             stringInJson(streamedJson, "vastaanottotieto") must_== "VASTAANOTTANUT_SITOVASTI"

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintaTulosServletSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintaTulosServletSpec.scala
@@ -265,6 +265,30 @@ class ValintaTulosServletSpec extends ServletSpecification {
         status must_== 200
       }
     }
+
+    "palauttaa haun hakukohteiden hakemusten tulokset vain merkitsevälle jonolle" in {
+
+      useFixture("hyvaksytty-kesken-julkaistavissa-korjattu.json")
+
+      checkData()
+
+      vastaanota("VastaanotaSitovasti") {
+        val hakukohdeOidsInPostBody = "[\"1.2.246.562.5.72607738902\"]".getBytes("UTF-8")
+        post("haku/streaming/1.2.246.562.5.2013080813081926341928/sijoitteluajo/latest/hakemukset?vainMerkitsevaJono=true",
+          hakukohdeOidsInPostBody,
+          headers = Map("Content-type" -> "application/json")) {
+            val streamedJson = JsonMethods.parse(body)
+            println("BO DY: " + body)
+            stringInJson(streamedJson, "hakijaOid") must_== "1.2.246.562.24.14229104472"
+            stringInJson(streamedJson, "hakemusOid") must_== "1.2.246.562.11.00000441369"
+            stringInJson(streamedJson, "vastaanottotieto") must_== "VASTAANOTTANUT_SITOVASTI"
+            (streamedJson \\ "hakutoiveet").asInstanceOf[JArray].arr.size must_== 1
+            (streamedJson \\ "hakutoiveenValintatapajonot").asInstanceOf[JArray].arr.size must_== 1
+            stringInJson(streamedJson, "valintatapajonoOid") must_== "14090336922663576781797489829886"
+            status must_== 200
+        }
+      }
+    }
   }
 
   "POST /haku/:hakuId/hakemus/:hakemusId/ilmoittaudu" should {

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/sijoittelu/ValintarekisteriHakijaDTOClientSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/sijoittelu/ValintarekisteriHakijaDTOClientSpec.scala
@@ -1,14 +1,11 @@
 package fi.vm.sade.valintatulosservice.sijoittelu
 
-import java.util
-
 import fi.vm.sade.sijoittelu.tulos.dto.raportointi.HakijaDTO
 import fi.vm.sade.valintatulosservice.ITSpecification
 import fi.vm.sade.valintatulosservice.valintarekisteri.domain.{HakemusOid, HakuOid}
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
-import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
 @RunWith(classOf[JUnitRunner])
@@ -30,7 +27,7 @@ class ValintarekisteriHakijaDTOClientSpec extends ITSpecification with Valintare
     def test(sijoitteluajoId:String, hakuOid:HakuOid, expectedSize:Int) = {
       val list = new ListBuffer[HakemusOid]
 
-      client.processSijoittelunTulokset(hakuOid, sijoitteluajoId, (hakija:HakijaDTO) => list += HakemusOid(hakija.getHakemusOid))
+      client.processSijoittelunTulokset(HakijaDTOSearchCriteria(hakuOid, sijoitteluajoId), (hakija:HakijaDTO) => list += HakemusOid(hakija.getHakemusOid))
 
       list.distinct.size must_== expectedSize
     }

--- a/valinta-tulos-valintarekisteri-db/src/main/resources/oph-configuration/valinta-tulos-service.properties.template
+++ b/valinta-tulos-valintarekisteri-db/src/main/resources/oph-configuration/valinta-tulos-service.properties.template
@@ -13,6 +13,8 @@ host.alb={{host_alb}}
 valinta-tulos-service.ohjausparametrit.url=https\://{{host_virkailija}}/ohjausparametrit-service/api/v1/rest/parametri
 valinta-tulos-service.ilmoittautuminen.enabled={{valintatulosservice_ilmoittautuminen_enabled}}
 
+valinta-tulos-service.streaming.hakukohde.concurrency={{valintatulosservice_streaming_hakukohde_concurrency | default('10') }}
+
 #SIJOITTELU-SERVICE
 sijoittelu-service.rest.url=https://{{host_virkailija}}/sijoittelu-service
 valinta-tulos-service.parseleniently.sijoitteluajontulos={{valintatulosservice_parseleniently_sijoitteluajontulos}}

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/sijoittelu/sijoitteluajonHakija.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/sijoittelu/sijoitteluajonHakija.scala
@@ -130,10 +130,13 @@ object SijoitteluajonHakijat {
   def dto(repository: HakijaRepository with SijoitteluRepository with ValinnantulosRepository,
           sijoitteluajoId:Option[Long],
           hakuOid:HakuOid,
-          hakukohdeOid: HakukohdeOid): List[HakijaDTO] = {
+          hakukohdeOid: HakukohdeOid,
+          haunValinnantulokset: Option[ValinnantuloksetGrouped] = None): List[HakijaDTO] = {
     val hakijat = repository.getHakukohteenHakijat(hakukohdeOid, sijoitteluajoId)
     val hakutoiveet = HakutoiveetGrouped.apply(sijoitteluajoId.map(repository.getHakukohteenHakemuksienHakutoiveetSijoittelussa(hakukohdeOid, _)).getOrElse(List()))
-    val valinnantulokset = timed("Valinnantulokset haulle", 100) { ValinnantuloksetGrouped.apply(repository.runBlocking(repository.getValinnantuloksetForHaku(hakuOid))) }
+    val valinnantulokset: ValinnantuloksetGrouped = haunValinnantulokset.getOrElse {
+      timed("Valinnantulokset haulle", 100) { ValinnantuloksetGrouped.apply(repository.runBlocking(repository.getValinnantuloksetForHaku(hakuOid))) }
+    }
     val valintatapajonot = ValintatapajonotGrouped.apply(sijoitteluajoId.map(repository.getHakukohteenHakemuksienValintatapajonotSijoittelussa(hakukohdeOid, _)).getOrElse(List()))
     val tilankuvauksetSijoittelussa = repository.getValinnantilanKuvaukset(valintatapajonot.tilankuvausHashit)
     val pistetiedotSijoittelussa = sijoitteluajoId.map(repository.getHakukohteenHakemuksienPistetiedotSijoittelussa(hakukohdeOid, _)).getOrElse(Map())


### PR DESCRIPTION
Suorituskykysyistä ulkoiset-rajapinnat -sovellus ei voi muodostaa
koko ison haun (tyypillisesti kevään kk-yhteishaku) tulostietoja kerralla,
vaan se pitää tehdä vain osalle haun hakukohteita kerrallaan.

Jotta tämän saa toteutettua järkevästi, myös ulkoiset-rajapinnat-
sovelluksen käyttämästä VTS:n APIsta pitää tehdä hakukohde-
oidilistaa tukeva versio. Sen toteutus on tässä branchissa.

Lisäksi branchissa on vähän refaktorointia ja syntaksin siivousta,
erillisissä commiteissa.