### PR TITLE
Bug 2010

### DIFF
--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/impl/ValinnantulosRepositoryImpl.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/impl/ValinnantulosRepositoryImpl.scala
@@ -70,10 +70,10 @@ trait ValinnantulosRepositoryImpl extends ValinnantulosRepository with Valintare
         and vth.tila = 'Hyvaksytty'
         and vt.julkaistavissa = 'true'
         and vth.transaction_id = (
-          select max(transaction_id)
-          from valinnantilat_history
-          where vth.hakemus_oid = ${hakemusOid}
-            and vth.hakukohde_oid = ${hakukohdeOid}
+          select max(vths.transaction_id)
+          from valinnantilat_history as vths
+          where vths.hakemus_oid = ${hakemusOid}
+            and vths.hakukohde_oid = ${hakukohdeOid}
       )""".as[Int].head)
   }
 


### PR DESCRIPTION
Olennainen korjaus on sql-kyselyssä:ssä, joka toimi ennen oikein vain jos hakuehdoilla löytyneitä transaction-id:itä oli ainoastaan yksi. Muuten vain pieni refaktorointi ja selkeämpi logitus kun tilanmuutos tehdään. 