### PR TITLE
VTKU-159 : jonokohtaisen alemman peruuntumisen piilotus

### DIFF
--- a/valinta-tulos-service/src/main/resources/fixtures/ValintaTulosServletSpec/expected-hyvaksytty-ehdollisesti-kesken-ei-julkaistavissa.json
+++ b/valinta-tulos-service/src/main/resources/fixtures/ValintaTulosServletSpec/expected-hyvaksytty-ehdollisesti-kesken-ei-julkaistavissa.json
@@ -43,6 +43,7 @@
       "tilanKuvaukset": {},
       "jonokohtaisetTulostiedot": [
         {
+          "oid": "14090336922663576781797489829886",
           "nimi": "Varsinainen jono",
           "valintatila": "KESKEN",
           "julkaistavissa": false,

--- a/valinta-tulos-service/src/main/resources/fixtures/ValintaTulosServletSpec/expected-hyvaksytty-ehdollisesti-kesken-julkaistavissa.json
+++ b/valinta-tulos-service/src/main/resources/fixtures/ValintaTulosServletSpec/expected-hyvaksytty-ehdollisesti-kesken-julkaistavissa.json
@@ -46,6 +46,7 @@
       "pisteet": 4.0,
       "jonokohtaisetTulostiedot": [
         {
+          "oid": "14090336922663576781797489829886",
           "nimi": "Varsinainen jono",
           "pisteet": 4.0,
           "alinHyvaksyttyPistemaara": 4.0,

--- a/valinta-tulos-service/src/main/resources/fixtures/ValintaTulosServletSpec/expected-hyvaksytty-ehdollisesti-syy-kesken-julkaistavissa.json
+++ b/valinta-tulos-service/src/main/resources/fixtures/ValintaTulosServletSpec/expected-hyvaksytty-ehdollisesti-syy-kesken-julkaistavissa.json
@@ -46,6 +46,7 @@
       "pisteet": 4.0,
       "jonokohtaisetTulostiedot": [
         {
+          "oid": "14090336922663576781797489829886",
           "nimi": "Varsinainen jono",
           "pisteet": 4.0,
           "alinHyvaksyttyPistemaara": 4.0,

--- a/valinta-tulos-service/src/main/resources/fixtures/ValintaTulosServletSpec/expected-hyvaksytty-kesken-ei-julkaistavissa.json
+++ b/valinta-tulos-service/src/main/resources/fixtures/ValintaTulosServletSpec/expected-hyvaksytty-kesken-ei-julkaistavissa.json
@@ -37,6 +37,7 @@
       "tilanKuvaukset": {},
       "jonokohtaisetTulostiedot": [
         {
+          "oid": "14090336922663576781797489829886",
           "nimi": "Varsinainen jono",
           "valintatila": "KESKEN",
           "julkaistavissa": false,
@@ -45,6 +46,7 @@
           "eiVarasijatayttoa": false
         },
         {
+          "oid": "14090336922663576781797489829887",
           "nimi": "Varsinainen jono",
           "valintatila": "KESKEN",
           "julkaistavissa": false,

--- a/valinta-tulos-service/src/main/resources/fixtures/ValintaTulosServletSpec/expected-hyvaksytty-kesken-julkaistavissa.json
+++ b/valinta-tulos-service/src/main/resources/fixtures/ValintaTulosServletSpec/expected-hyvaksytty-kesken-julkaistavissa.json
@@ -42,6 +42,7 @@
       "pisteet": 4.0,
       "jonokohtaisetTulostiedot": [
         {
+          "oid": "14090336922663576781797489829886",
           "nimi": "Varsinainen jono",
           "pisteet": 4.0,
           "alinHyvaksyttyPistemaara": 4.0,
@@ -54,6 +55,7 @@
           "eiVarasijatayttoa": false
         },
         {
+          "oid": "14090336922663576781797489829887",
           "nimi": "Varsinainen jono",
           "valintatila": "KESKEN",
           "julkaistavissa": false,

--- a/valinta-tulos-service/src/main/resources/fixtures/ValintaTulosServletSpec/expected-hyvaksytty-kesken-julkaistavissa.json
+++ b/valinta-tulos-service/src/main/resources/fixtures/ValintaTulosServletSpec/expected-hyvaksytty-kesken-julkaistavissa.json
@@ -43,7 +43,7 @@
       "jonokohtaisetTulostiedot": [
         {
           "oid": "14090336922663576781797489829886",
-          "nimi": "Varsinainen jono",
+          "nimi": "Varsinainen ylempi jono",
           "pisteet": 4.0,
           "alinHyvaksyttyPistemaara": 4.0,
           "valintatila": "HYVAKSYTTY",
@@ -56,10 +56,10 @@
         },
         {
           "oid": "14090336922663576781797489829887",
-          "nimi": "Varsinainen jono",
+          "nimi": "Varsinainen alempi jono",
           "valintatila": "KESKEN",
           "julkaistavissa": false,
-          "valintatapajonoPrioriteetti": 0,
+          "valintatapajonoPrioriteetti": 1,
           "ehdollisestiHyvaksyttavissa": false,
           "eiVarasijatayttoa": false
         }

--- a/valinta-tulos-service/src/main/resources/fixtures/sijoittelu/hyvaksytty-kesken-julkaistavissa.json
+++ b/valinta-tulos-service/src/main/resources/fixtures/sijoittelu/hyvaksytty-kesken-julkaistavissa.json
@@ -50,7 +50,7 @@
         {
           "tasasijasaanto": "YLITAYTTO",
           "oid": "14090336922663576781797489829886",
-          "nimi": "Varsinainen jono",
+          "nimi": "Varsinainen ylempi jono",
           "prioriteetti": 0,
           "aloituspaikat": 3,
           "eiVarasijatayttoa": false,
@@ -92,8 +92,8 @@
         {
           "tasasijasaanto": "YLITAYTTO",
           "oid": "14090336922663576781797489829887",
-          "nimi": "Varsinainen jono",
-          "prioriteetti": 0,
+          "nimi": "Varsinainen alempi jono",
+          "prioriteetti": 1,
           "aloituspaikat": 3,
           "eiVarasijatayttoa": false,
           "kaikkiEhdonTayttavatHyvaksytaan": false,

--- a/valinta-tulos-service/src/main/resources/fixtures/sijoittelu/samassa-kohteessa-julkaisematon-hyvaksytty-ja-julkaistu-peruuntunut.json
+++ b/valinta-tulos-service/src/main/resources/fixtures/sijoittelu/samassa-kohteessa-julkaisematon-hyvaksytty-ja-julkaistu-peruuntunut.json
@@ -1,0 +1,171 @@
+{
+  "Sijoittelu": [
+    {
+      "_id": {
+        "$oid": "547f0c17e4b0755315d44e0a"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Sijoittelu",
+      "hakuOid": "1.2.246.562.5.2013080813081926341928",
+      "sijoitteluId": {
+        "$numberLong": "1496148928083"
+      },
+      "created": {
+        "$date": "2014-12-03T13:11:51.186Z"
+      },
+      "sijoittele": true,
+      "sijoitteluajot": [
+        {
+          "sijoitteluajoId": {
+            "$numberLong": "1496148928083"
+          },
+          "startMils": {
+            "$numberLong": "14961489280831"
+          },
+          "endMils": {
+            "$numberLong": "14961499280831"
+          },
+          "hakuOid": "1.2.246.562.5.2013080813081926341928",
+          "hakukohteet": [
+            {
+              "oid": "1.2.246.562.5.72607738902"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "Hakukohde": [
+    {
+      "_id": {
+        "$oid": "53fc79b8e4b0b0b110900764"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Hakukohde",
+      "sijoitteluajoId": {
+        "$numberLong": "1496148928083"
+      },
+      "oid": "1.2.246.562.5.72607738902",
+      "tarjoajaOid": "1.2.246.562.10.591352080610",
+      "kaikkiJonotSijoiteltu": true,
+      "valintatapajonot": [
+        {
+          "tasasijasaanto": "YLITAYTTO",
+          "oid": "14090336922663576781797489829887",
+          "nimi": "Alemman prioriteetin jono",
+          "prioriteetti": 1,
+          "aloituspaikat": 3,
+          "eiVarasijatayttoa": false,
+          "kaikkiEhdonTayttavatHyvaksytaan": false,
+          "poissaOlevaTaytto": false,
+          "hyvaksytty": 0,
+          "varalla": 0,
+          "alinHyvaksyttyPistemaara": 4,
+          "varasijojaKaytetaanAlkaen": {
+            "$date": "2014-08-26T16:05:23.943Z"
+          },
+          "varasijojaTaytetaanAsti": {
+            "$date": "2014-08-26T16:05:23.943Z"
+          },
+          "hakemukset": [
+            {
+              "hakijaOid": "1.2.246.562.24.14229104472",
+              "hakemusOid": "1.2.246.562.11.00000441369",
+              "etunimi": "Teppo",
+              "sukunimi": "Testaaja",
+              "prioriteetti": 2,
+              "jonosija": 1,
+              "pisteet": 4,
+              "tasasijaJonosija": 1,
+              "tila": "PERUUNTUNUT",
+              "tilaHistoria": [
+                {
+                  "luotu": {
+                    "$date": "2014-08-26T15:12:40.623Z"
+                  },
+                  "tila": "PERUUNTUNUT"
+                }
+              ],
+              "hyvaksyttyHarkinnanvaraisesti": false,
+              "tilankuvauksenTarkenne": "PERUUNTUNUT_HYVAKSYTTY_TOISESSA_JONOSSA"
+            }
+          ]
+        },
+        {
+          "tasasijasaanto": "YLITAYTTO",
+          "oid": "14090336922663576781797489829886",
+          "nimi": "Ylemmän prioriteetin jono",
+          "prioriteetti": 0,
+          "aloituspaikat": 3,
+          "eiVarasijatayttoa": false,
+          "kaikkiEhdonTayttavatHyvaksytaan": false,
+          "poissaOlevaTaytto": false,
+          "hyvaksytty": 1,
+          "varalla": 0,
+          "alinHyvaksyttyPistemaara": 4,
+          "varasijojaKaytetaanAlkaen": {
+            "$date": "2014-08-26T16:05:23.943Z"
+          },
+          "varasijojaTaytetaanAsti": {
+            "$date": "2014-08-26T16:05:23.943Z"
+          },
+          "hakemukset": [
+            {
+              "hakijaOid": "1.2.246.562.24.14229104472",
+              "hakemusOid": "1.2.246.562.11.00000441369",
+              "etunimi": "Teppo",
+              "sukunimi": "Testaaja",
+              "prioriteetti": 1,
+              "jonosija": 1,
+              "pisteet": 4,
+              "tasasijaJonosija": 1,
+              "tila": "HYVAKSYTTY",
+              "tilaHistoria": [
+                {
+                  "luotu": {
+                    "$date": "2013-08-26T15:12:40.623Z"
+                  },
+                  "tila": "HYVAKSYTTY"
+                }
+              ],
+              "hyvaksyttyHarkinnanvaraisesti": false,
+              "tilankuvauksenTarkenne": "EI_TILANKUVAUKSEN_TARKENNETTA"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "Valintatulos": [
+    {
+      "_id": {
+        "$oid": "53fc8613e4b0b0b110900766"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Valintatulos",
+      "valintatapajonoOid": "14090336922663576781797489829886",
+      "hakemusOid": "1.2.246.562.11.00000441369",
+      "hakukohdeOid": "1.2.246.562.5.72607738902",
+      "hakijaOid": "1.2.246.562.24.14229104472",
+      "hakuOid": "1.2.246.562.5.2013080813081926341928",
+      "hakutoive": 1,
+      "tila": "KESKEN",
+      "ilmoittautumisTila": "EI_TEHTY",
+      "julkaistavissa": false,
+      "logEntries": []
+    },
+    {
+      "_id": {
+        "$oid": "53fc8613e4b0b0b110900767"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Valintatulos",
+      "valintatapajonoOid": "14090336922663576781797489829887",
+      "hakemusOid": "1.2.246.562.11.00000441369",
+      "hakukohdeOid": "1.2.246.562.5.72607738902",
+      "hakijaOid": "1.2.246.562.24.14229104472",
+      "hakuOid": "1.2.246.562.5.2013080813081926341928",
+      "hakutoive": 1,
+      "tila": "KESKEN",
+      "ilmoittautumisTila": "EI_TEHTY",
+      "julkaistavissa": true,
+      "logEntries": []
+    }
+  ]
+}

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
@@ -489,11 +489,11 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
 
     val lopullisetTulokset = Välitulos(sijoitteluTulos.hakemusOid, tulokset, haku, ohjausparametrit)
       .map(näytäHyväksyttyäJulkaisematontaAlemmistaKorkeinHyvaksyttyOdottamassaYlempiä)
-      .map(näytäJulkaisematontaAlemmatPeruutetutKeskeneräisinä)
-      .map(peruValmistaAlemmatKeskeneräisetJosKäytetäänSijoittelua)
+      .map(näytäJulkaisematontaAlemmatPeruuntuneetKeskeneräisinä)
+      .map(peruunnutaValmistaAlemmatKeskeneräisetJosKäytetäänSijoittelua)
       .map(näytäVarasijaltaHyväksytytHyväksyttyinäJosVarasijasäännötEiVoimassa)
       .map(sovellaSijoitteluaKayttanvaKorkeakouluhaunSaantoja)
-      .map(näytäAlemmatPeruutuneetKeskeneräisinäJosYlemmätKeskeneräisiä)
+      .map(näytäAlemmatPeruuntuneetKeskeneräisinäJosYlemmätKeskeneräisiä)
       .map(piilotaKuvauksetKeskeneräisiltä)
       .map(asetaVastaanotettavuusValintarekisterinPerusteella(vastaanottoKaudella))
       .map(asetaKelaURL)
@@ -801,30 +801,30 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
     }
   }
 
-  private def peruValmistaAlemmatKeskeneräisetJosKäytetäänSijoittelua(hakemusOid: HakemusOid, tulokset: List[Hakutoiveentulos], haku: Haku, ohjausparametrit: Ohjausparametrit) = {
+  private def peruunnutaValmistaAlemmatKeskeneräisetJosKäytetäänSijoittelua(hakemusOid: HakemusOid, tulokset: List[Hakutoiveentulos], haku: Haku, ohjausparametrit: Ohjausparametrit) = {
     if (haku.sijoitteluJaPriorisointi) {
       val firstFinished = tulokset.indexWhere { t =>
         isHyväksytty(t.valintatila) || t.valintatila == Valintatila.perunut
       }
       tulokset.zipWithIndex.map {
         case (tulos, index) if firstFinished > -1 && index > firstFinished && tulos.valintatila == Valintatila.kesken =>
-          logger.debug("peruValmistaAlemmatKeskeneräisetJosKäytetäänSijoittelua valintatila > peruuntunut {}", index)
+          logger.debug("peruunnutaValmistaAlemmatKeskeneräisetJosKäytetäänSijoittelua valintatila > peruuntunut {}", index)
           tulos.copy(valintatila = Valintatila.peruuntunut)
         case (tulos, _) =>
           tulos
       }
     } else {
-      logger.debug("peruValmistaAlemmatKeskeneräisetJosKäytetäänSijoittelua ei käytä sijoittelua")
+      logger.debug("peruunnutaValmistaAlemmatKeskeneräisetJosKäytetäänSijoittelua ei käytä sijoittelua")
       tulokset
     }
   }
 
 
-  private def näytäAlemmatPeruutuneetKeskeneräisinäJosYlemmätKeskeneräisiä(hakemusOid: HakemusOid, tulokset: List[Hakutoiveentulos], haku: Haku, ohjausparametrit: Ohjausparametrit) = {
+  private def näytäAlemmatPeruuntuneetKeskeneräisinäJosYlemmätKeskeneräisiä(hakemusOid: HakemusOid, tulokset: List[Hakutoiveentulos], haku: Haku, ohjausparametrit: Ohjausparametrit) = {
     val firstKeskeneräinen: Int = tulokset.indexWhere (_.valintatila == Valintatila.kesken)
     tulokset.zipWithIndex.map {
       case (tulos, index) if firstKeskeneräinen >= 0 && index > firstKeskeneräinen && tulos.valintatila == Valintatila.peruuntunut =>
-        logger.debug("näytäAlemmatPeruutuneetKeskeneräisinäJosYlemmätKeskeneräisiä toKesken {}", index)
+        logger.debug("näytäAlemmatPeruuntuneetKeskeneräisinäJosYlemmätKeskeneräisiä toKesken {}", index)
         tulos.toKesken
       case (tulos, _) =>
         logger.debug("tulos.valintatila "+tulos.valintatila)
@@ -832,14 +832,14 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
     }
   }
 
-  private def näytäJulkaisematontaAlemmatPeruutetutKeskeneräisinä(hakemusOid: HakemusOid, tulokset: List[Hakutoiveentulos], haku: Haku, ohjausparametrit: Ohjausparametrit) = {
+  private def näytäJulkaisematontaAlemmatPeruuntuneetKeskeneräisinä(hakemusOid: HakemusOid, tulokset: List[Hakutoiveentulos], haku: Haku, ohjausparametrit: Ohjausparametrit) = {
     val firstJulkaisematon: Int = tulokset.indexWhere (!_.julkaistavissa)
     tulokset.zipWithIndex.map {
       case (tulos, index) if firstJulkaisematon >= 0 && index > firstJulkaisematon && tulos.valintatila == Valintatila.peruuntunut =>
-        logger.debug("näytäJulkaisematontaAlemmatPeruutetutKeskeneräisinä toKesken {}", index)
+        logger.debug("näytäJulkaisematontaAlemmatPeruuntuneetKeskeneräisinä toKesken {}", index)
         tulos.toKesken
       case (tulos, _) =>
-        logger.debug("näytäJulkaisematontaAlemmatPeruutetutKeskeneräisinä {}", tulos.valintatila)
+        logger.debug("näytäJulkaisematontaAlemmatPeruuntuneetKeskeneräisinä {}", tulos.valintatila)
         tulos
     }
   }

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
@@ -837,7 +837,15 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
     tulokset.zipWithIndex.map {
       case (tulos, index) if firstJulkaisematon >= 0 && index > firstJulkaisematon && tulos.valintatila == Valintatila.peruuntunut =>
         logger.debug("näytäJulkaisematontaAlemmatPeruuntuneetKeskeneräisinä toKesken {}", index)
-        tulos.toKesken
+        tulos.
+          toKesken.
+          copy(jonokohtaisetTulostiedot = tulos.jonokohtaisetTulostiedot.map { t =>
+            if (t.valintatila == Valintatila.peruuntunut || Valintatila.isHyväksytty(t.valintatila)) {
+              t.toKesken
+            } else {
+              t
+            }
+        })
       case (tulos, _) =>
         logger.debug("näytäJulkaisematontaAlemmatPeruuntuneetKeskeneräisinä {}", tulos.valintatila)
         tulos

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
@@ -23,7 +23,6 @@ import fi.vm.sade.valintatulosservice.vastaanotto.VastaanottoUtils.ehdollinenVas
 import org.apache.commons.lang3.StringUtils
 
 import scala.collection.JavaConverters._
-import scala.collection.immutable
 
 class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
                           sijoittelutulosService: SijoittelutulosService,
@@ -894,7 +893,9 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
               jonokohtaisetTulostiedot = tulos.jonokohtaisetTulostiedot.map {
                 jonokohtainenTulostieto =>
                   if (jonoJostaOliHyvaksyttyJulkaistu.contains(jonokohtainenTulostieto.oid) && jonokohtainenTulostieto.valintatila == Valintatila.peruuntunut) {
-                    jonokohtainenTulostieto.copy(valintatila = Valintatila.hyväksytty)
+                    jonokohtainenTulostieto.copy(
+                      valintatila = Valintatila.hyväksytty,
+                      tilanKuvaukset = None)
                   } else {
                     jonokohtainenTulostieto
                   }

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
@@ -882,7 +882,7 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
               tilanKuvaukset = Map.empty,
               jonokohtaisetTulostiedot = tulos.jonokohtaisetTulostiedot.map {
                 jonokohtainenTulostieto =>
-                  if (jonoJostaOliHyvaksyttyJulkaistu.contains(jonokohtainenTulostieto.oid) && jonokohtainenTulostieto.valintatila == Valintatila.peruuntunut) {
+                  if (jonoJostaOliHyvaksyttyJulkaistu.get == jonokohtainenTulostieto.oid && jonokohtainenTulostieto.valintatila == Valintatila.peruuntunut) {
                     jonokohtainenTulostieto.copy(
                       valintatila = Valintatila.hyväksytty,
                       tilanKuvaukset = None)

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/domain/Hakemuksentulos.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/domain/Hakemuksentulos.scala
@@ -53,6 +53,8 @@ case class Hakutoiveentulos(hakukohdeOid: HakukohdeOid,
                             jonokohtaisetTulostiedot: List[JonokohtainenTulostieto]
                             ) {
 
+  def jonokohtaisetTulostiedotPrioriteettiJarjestyksessa: List[JonokohtainenTulostieto] = jonokohtaisetTulostiedot.sortBy(_.valintatapajonoPrioriteetti)
+
   def toKesken = {
     copy(
         valintatila = Valintatila.kesken,

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/SijoittelutulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/SijoittelutulosService.scala
@@ -209,6 +209,7 @@ class SijoittelutulosService(raportointiService: ValintarekisteriRaportointiServ
           .getHakutoiveenValintatapajonot
           .map(valintatapajono => {
             JonokohtainenTulostieto(
+              oid = ValintatapajonoOid(valintatapajono.getValintatapajonoOid),
               nimi = valintatapajono.getValintatapajonoNimi,
               pisteet = Option(valintatapajono.getPisteet).map((p: java.math.BigDecimal) => new BigDecimal(p)),
               alinHyvaksyttyPistemaara = Option(valintatapajono.getAlinHyvaksyttyPistemaara).map((p: java.math.BigDecimal) => new BigDecimal(p)),

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
@@ -578,7 +578,16 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
           "Valintatulos julkaistavissa, mutta haun valintatulosten julkaisu paivamaara tulevaisuudessa" in {
             // HYVAKSYTTY, PERUUNTUNUT KESKEN true
             useFixture("hyvaksytty-kesken-julkaistavissa.json", hakuFixture = hakuFixture, ohjausparametritFixture = OhjausparametritFixtures.tuloksiaEiVielaSaaJulkaista)
-            checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
+            val hakutoiveentulos = getHakutoive("1.2.246.562.5.72607738902")
+            checkHakutoiveState(hakutoiveentulos, Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
+
+            hakutoiveentulos.jonokohtaisetTulostiedot.size must_== 2
+            val ylemmanJononTulos = hakutoiveentulos.jonokohtaisetTulostiedot.find(_.oid == ValintatapajonoOid("14090336922663576781797489829886"))
+            val alemmanJononTulos = hakutoiveentulos.jonokohtaisetTulostiedot.find(_.oid == ValintatapajonoOid("14090336922663576781797489829887"))
+            ylemmanJononTulos.get.valintatila must_== Valintatila.kesken
+            ylemmanJononTulos.get.julkaistavissa must_== false
+            alemmanJononTulos.get.valintatila must_== Valintatila.kesken
+            alemmanJononTulos.get.julkaistavissa must_== false
           }
 
           "Valintatulos julkaistavissa ja haun julkaisu paivamaara mennyt" in {

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
@@ -268,7 +268,12 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
 
 
         checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
-        checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738903"), Valintatila.hyväksytty, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
+        val alempiPeruuntunutTulosJokaOnKaannettyHyvaksytyksi = getHakutoive("1.2.246.562.5.72607738903")
+        checkHakutoiveState(alempiPeruuntunutTulosJokaOnKaannettyHyvaksytyksi, Valintatila.hyväksytty, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
+        val jonokohtaisetTulostiedotAlemmaltaHyvaksytyksiKaannetylta: Seq[JonokohtainenTulostieto] = alempiPeruuntunutTulosJokaOnKaannettyHyvaksytyksi.jonokohtaisetTulostiedot.sortBy(_.valintatapajonoPrioriteetti)
+        jonokohtaisetTulostiedotAlemmaltaHyvaksytyksiKaannetylta(0).valintatila must_== Valintatila.peruuntunut
+        jonokohtaisetTulostiedotAlemmaltaHyvaksytyksiKaannetylta(1).valintatila must_== Valintatila.hyväksytty
+        jonokohtaisetTulostiedotAlemmaltaHyvaksytyksiKaannetylta(2).valintatila must_== Valintatila.peruuntunut
         checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738904"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
 
         // Julkaistaan tulos:

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
@@ -1,7 +1,5 @@
 package fi.vm.sade.valintatulosservice.local
 
-import java.util.concurrent.TimeUnit
-
 import fi.vm.sade.sijoittelu.domain.{ValintatuloksenTila, Valintatulos}
 import fi.vm.sade.valintatulosservice.domain.Valintatila._
 import fi.vm.sade.valintatulosservice.domain.Vastaanotettavuustila.Vastaanotettavuustila
@@ -21,8 +19,6 @@ import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import slick.jdbc.PostgresProfile.api._
-
-import scala.concurrent.duration.Duration
 
 @RunWith(classOf[JUnitRunner])
 class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
@@ -263,8 +259,7 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
           .andThen(valintarekisteriDb.storeValinnantila(hakemuksen21tila, None))
           .andThen(valintarekisteriDb.storeValinnantila(hakemuksen22tila, None))
           .andThen(valintarekisteriDb.storeValinnantila(hakemuksen1tila, None))
-        .transactionally,
-        Duration(60, TimeUnit.MINUTES))
+        .transactionally)
 
 
         checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
@@ -336,8 +331,7 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
           .andThen(valintarekisteriDb.storeValinnantila(hakemuksen22tila, None))
           .andThen(valintarekisteriDb.storeValinnantila(hakemuksen23tila, None))
           .andThen(valintarekisteriDb.storeValinnantila(hakemuksen1tila, None))
-        .transactionally,
-        Duration(60, TimeUnit.MINUTES))
+        .transactionally)
 
 
         checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
@@ -376,8 +370,7 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
 
         valintarekisteriDb.runBlocking(valintarekisteriDb.storeValinnantila(hakemuksen1tilaHyvaksytty, None)
             .andThen(valintarekisteriDb.storeValinnantila(hakemuksen2tilaPeruuntunut, None))
-            .transactionally,
-          Duration(10, TimeUnit.MINUTES))
+            .transactionally)
 
         // BUG-2026 reproduction step 3
         // HYVAKSYTTY KESKEN false
@@ -400,40 +393,31 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
 
         //Poistetaan kannasta 2. hakutoiveen valintatilan tiedot:
         valintarekisteriDb.runBlocking(sqlu"delete from jonosijat where valintatapajono_oid = '14090336922663576781797489829885' and hakukohde_oid = '1.2.246.562.5.72607738903'"
-          .transactionally,
-          Duration(60, TimeUnit.MINUTES))
+          .transactionally)
 
         valintarekisteriDb.runBlocking(sqlu"delete from valintatapajonot where oid = '14090336922663576781797489829885'"
-          .transactionally,
-          Duration(60, TimeUnit.MINUTES))
+          .transactionally)
 
         valintarekisteriDb.runBlocking(sqlu"delete from tilat_kuvaukset where hakukohde_oid = '1.2.246.562.5.72607738903' and hakemus_oid = '1.2.246.562.11.00000441369' and valintatapajono_oid = '14090336922663576781797489829885'"
-          .transactionally,
-          Duration(60, TimeUnit.MINUTES))
+          .transactionally)
 
         valintarekisteriDb.runBlocking(sqlu"delete from tilat_kuvaukset_history where hakukohde_oid = '1.2.246.562.5.72607738903' and hakemus_oid = '1.2.246.562.11.00000441369' and valintatapajono_oid = '14090336922663576781797489829885'"
-          .transactionally,
-          Duration(60, TimeUnit.MINUTES))
+          .transactionally)
 
         valintarekisteriDb.runBlocking(sqlu"delete from valinnantulokset where hakukohde_oid = '1.2.246.562.5.72607738903' and hakemus_oid = '1.2.246.562.11.00000441369'"
-          .transactionally,
-          Duration(60, TimeUnit.MINUTES))
+          .transactionally)
 
         valintarekisteriDb.runBlocking(sqlu"delete from valinnantulokset_history where hakukohde_oid = '1.2.246.562.5.72607738903' and hakemus_oid = '1.2.246.562.11.00000441369'"
-          .transactionally,
-          Duration(60, TimeUnit.MINUTES))
+          .transactionally)
 
         valintarekisteriDb.runBlocking(sqlu"delete from valinnantilat where hakukohde_oid = '1.2.246.562.5.72607738903' and hakemus_oid = '1.2.246.562.11.00000441369'"
-          .transactionally,
-          Duration(60, TimeUnit.MINUTES))
+          .transactionally)
 
         valintarekisteriDb.runBlocking(sqlu"delete from valinnantilat_history where hakukohde_oid = '1.2.246.562.5.72607738903' and hakemus_oid = '1.2.246.562.11.00000441369'"
-          .transactionally,
-          Duration(60, TimeUnit.MINUTES))
+          .transactionally)
 
         valintarekisteriDb.runBlocking(sqlu"delete from sijoitteluajon_hakukohteet where hakukohde_oid = '1.2.246.562.5.72607738903'"
-          .transactionally,
-          Duration(60, TimeUnit.MINUTES))
+          .transactionally)
 
         val hakemuksen1tila = ValinnantilanTallennus(HakemusOid("1.2.246.562.11.00000441369"),
           ValintatapajonoOid("14090336922663576781797489829884"),
@@ -453,8 +437,7 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
         valintarekisteriDb.runBlocking(sqlu"update valinnantulokset set julkaistavissa = 'false' where hakukohde_oid = '1.2.246.562.5.72607738902' and valintatapajono_oid = '14090336922663576781797489829884' and hakemus_oid = '1.2.246.562.11.00000441369'"
           .andThen(valintarekisteriDb.storeValinnantila(hakemuksen3tila, None))
           .andThen(valintarekisteriDb.storeValinnantila(hakemuksen1tila, None))
-          .transactionally,
-          Duration(60, TimeUnit.MINUTES))
+          .transactionally)
 
 
         checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
@@ -288,8 +288,16 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
         // HYVÄKSYTTY KESKEN true
         // Ajetaan ensin historiadata
         useFixture("hyvaksytty-ylempi-ei-julkaistu-alempi-peruuntunut-historia.json", hakuFixture = hakuFixture, hakemusFixtures = List("00000441369-3"))
+
         checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738902"), Valintatila.kesken, Vastaanottotila.kesken, Vastaanotettavuustila. ei_vastaanotettavissa, true)
+        getHakutoive("1.2.246.562.5.72607738902").jonokohtaisetTulostiedot.head.valintatila must_== Valintatila.varalla
+
         checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738903"), Valintatila.hyväksytty, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
+        getHakutoive("1.2.246.562.5.72607738903").jonokohtaisetTulostiedot.size must_== 3
+        getHakutoive("1.2.246.562.5.72607738903").jonokohtaisetTulostiedot.head.valintatila must_== Valintatila.varalla
+        getHakutoive("1.2.246.562.5.72607738903").jonokohtaisetTulostiedot(1).valintatila must_== Valintatila.hyväksytty
+        getHakutoive("1.2.246.562.5.72607738903").jonokohtaisetTulostiedot(2).valintatila must_== Valintatila.peruuntunut
+
         checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738904"), Valintatila.hyväksytty, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, true)
 
         val hakemuksen1tila = ValinnantilanTallennus(HakemusOid("1.2.246.562.11.00000441369"),

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/ValinnantulosRepository.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/ValinnantulosRepository.scala
@@ -26,7 +26,7 @@ trait ValinnantulosRepository extends ValintarekisteriRepository {
 
   def getMuutoshistoriaForHakemus(hakemusOid: HakemusOid, valintatapajonoOid: ValintatapajonoOid): List[Muutos]
 
-  def getViimeisinValinnantilaMuutosHyvaksyttyJaJulkaistuCountHistoriasta(hakemusOid: HakemusOid, hakukohdeOid: HakukohdeOid): Int
+  def getViimeisinValinnantilaMuutosHyvaksyttyJaJulkaistuJonoOidHistoriasta(hakemusOid: HakemusOid, hakukohdeOid: HakukohdeOid): Option[ValintatapajonoOid]
 
   def getValinnantuloksetForHakukohde(hakukohdeOid: HakukohdeOid): DBIO[Set[Valinnantulos]]
   def getValinnantuloksetForValintatapajono(valintatapajonoOid: ValintatapajonoOid): Set[Valinnantulos]

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/impl/ValinnantulosRepositoryImpl.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/impl/ValinnantulosRepositoryImpl.scala
@@ -60,8 +60,8 @@ trait ValinnantulosRepositoryImpl extends ValinnantulosRepository with Valintare
       }.groupBy(_._3.field).mapValues(formMuutoshistoria).values.flatten)
   }
 
-  override def getViimeisinValinnantilaMuutosHyvaksyttyJaJulkaistuCountHistoriasta(hakemusOid: HakemusOid, hakukohdeOid: HakukohdeOid): Int = {
-    runBlocking(sql"""select count(*)
+  override def getViimeisinValinnantilaMuutosHyvaksyttyJaJulkaistuJonoOidHistoriasta(hakemusOid: HakemusOid, hakukohdeOid: HakukohdeOid): Option[ValintatapajonoOid] = {
+    runBlocking(sql"""select vth.valintatapajono_oid
       from valinnantilat_history vth
       where vth.hakemus_oid = ${hakemusOid}
         and vth.hakukohde_oid = ${hakukohdeOid}
@@ -90,7 +90,7 @@ trait ValinnantulosRepositoryImpl extends ValinnantulosRepository with Valintare
                   and th.valintatapajono_oid = vth.valintatapajono_oid
                   and th.julkaistavissa = 'true'
                   and th.system_time && vth.system_time
-                  limit 1))""".as[Int].head)
+                  limit 1))""".as[String].headOption).map(ValintatapajonoOid)
   }
 
   private def getValinnantulosMuutos(hakemusOid: HakemusOid, valintatapajonoOid: ValintatapajonoOid): MuutosDBIOAction = {

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/domain/JonokohtainenTulostieto.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/domain/JonokohtainenTulostieto.scala
@@ -4,6 +4,7 @@ import fi.vm.sade.valintatulosservice.domain.Valintatila
 import fi.vm.sade.valintatulosservice.domain.Valintatila.Valintatila
 
 case class JonokohtainenTulostieto(
+                                  oid: ValintatapajonoOid,
                                   nimi: String,
                                   pisteet: Option[BigDecimal],
                                   alinHyvaksyttyPistemaara: Option[BigDecimal],

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/domain/JonokohtainenTulostieto.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/domain/JonokohtainenTulostieto.scala
@@ -23,7 +23,11 @@ case class JonokohtainenTulostieto(
       valintatila = Valintatila.kesken,
       pisteet = None,
       alinHyvaksyttyPistemaara = None,
-      varasijanumero = None
+      varasijanumero = None,
+      julkaistavissa = false,
+      tilanKuvaukset = None,
+      ehdollisestiHyvaksyttavissa = false,
+      ehdollisenHyvaksymisenEhto = None
     )
   }
 }


### PR DESCRIPTION
- piilotetaan alempien toiveiden hyväksymiset myös jonotasolta, jos ylempi hyväksytty toive ei vielä ole julkaistu
- jos ylemmän jonon tulos on julkaisematon kesken, näytetään alempi jono myös kesken-tilaisena, jos se on peruuntunut (sen pitäisi olla peruuntunut koska ylempi on julkaistu)
- jos alemman toiveen tila käännetään peruuntuneesta hyväksytyksi, kun ylemmän toiveen hyväksyttyä tulosta ei ole vielä julkaistu, mutta alempi toive on aiemmin julkaistu hyväksyttynä (eli "Hyväksytty (odottaa ylempiä toiveita)"), niin siivotaan tilankuvauksen tarkenne jonotasolta. Muuten siellä lukee esim "Hyväksytty / Peruuntunut, hyväksytty ylemmälle hakutoiveelle".
- lanataan jonokohtaisessa .toKesken suunnilleen samat tiedot kuin hakukohdetasoisessa
- nimien siistimistä
- tilankuvaustekstit luetaan samasta paikasta kuin sijoittelu ne lukee (itse asiassa tämän voisi vielä muuttaa niin, että tulokseen tallennettaisiin vain tarkenne-enum eikä string-mappia)