### PR TITLE
VTKU-187 : alempi julkaisematon hyväksytty näkyy virheellisesti

### DIFF
--- a/valinta-tulos-service/src/main/resources/fixtures/sijoittelu/ylin-toive-hyvaksytty-toisesta-jonosta-mutta-julkaisematon-alempi-peruuntunut.json
+++ b/valinta-tulos-service/src/main/resources/fixtures/sijoittelu/ylin-toive-hyvaksytty-toisesta-jonosta-mutta-julkaisematon-alempi-peruuntunut.json
@@ -1,0 +1,216 @@
+{
+  "Sijoittelu": [
+    {
+      "_id": {
+        "$oid": "547f0c17e4b0755315d44e0a"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Sijoittelu",
+      "hakuOid": "1.2.246.562.5.2013080813081926341928",
+      "sijoitteluId": {
+        "$numberLong": "1496148928094"
+      },
+      "created": {
+        "$date": "2018-06-11T13:11:51.186Z"
+      },
+      "sijoittele": true,
+      "sijoitteluajot": [
+        {
+          "sijoitteluajoId": {
+            "$numberLong": "1496148928094"
+          },
+          "hakuOid": "1.2.246.562.5.2013080813081926341928",
+          "hakukohteet": [
+            {
+              "oid": "1.2.246.562.5.72607738903"
+            },
+            {
+              "oid": "1.2.246.562.5.72607738904"
+            }
+          ],
+          "startMils": {
+            "$numberLong": "14961489280951"
+          },
+          "endMils": {
+            "$numberLong": "14961499280951"
+          }
+        }
+      ]
+    }
+  ],
+  "Hakukohde": [
+    {
+      "_id": {
+        "$oid": "53fc79b8e4b0b0b110900765"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Hakukohde",
+      "sijoitteluajoId": {
+        "$numberLong": "1496148928094"
+      },
+      "oid": "1.2.246.562.5.72607738903",
+      "tarjoajaOid": "1.2.246.562.10.591352080610",
+      "kaikkiJonotSijoiteltu": true,
+      "valintatapajonot": [
+        {
+          "tasasijasaanto": "YLITAYTTO",
+          "oid": "14090336922663576781797489829885",
+          "nimi": "Todistusvalintajono",
+          "prioriteetti": 0,
+          "aloituspaikat": 3,
+          "eiVarasijatayttoa": false,
+          "kaikkiEhdonTayttavatHyvaksytaan": false,
+          "poissaOlevaTaytto": false,
+          "hakemukset": [
+            {
+              "hakijaOid": "1.2.246.562.24.14229104472",
+              "hakemusOid": "1.2.246.562.11.00000441369",
+              "etunimi": "Teppo",
+              "sukunimi": "Testaaja",
+              "prioriteetti": 0,
+              "jonosija": 10,
+              "pisteet": 4,
+              "tasasijaJonosija": 1,
+              "tila": "VARALLA",
+              "hyvaksyttyHarkinnanvaraisesti": false,
+              "tilankuvauksenTarkenne": "EI_TILANKUVAUKSEN_TARKENNETTA"
+            }
+          ]
+        },
+        {
+          "tasasijasaanto": "YLITAYTTO",
+          "oid": "14090336922663576781797489829886",
+          "nimi": "Koepistejono",
+          "prioriteetti": 1,
+          "aloituspaikat": 3,
+          "eiVarasijatayttoa": false,
+          "kaikkiEhdonTayttavatHyvaksytaan": false,
+          "poissaOlevaTaytto": false,
+          "hakemukset": [
+            {
+              "hakijaOid": "1.2.246.562.24.14229104472",
+              "hakemusOid": "1.2.246.562.11.00000441369",
+              "etunimi": "Teppo",
+              "sukunimi": "Testaaja",
+              "prioriteetti": 0,
+              "jonosija": 1,
+              "pisteet": 4,
+              "tasasijaJonosija": 1,
+              "tila": "HYVAKSYTTY",
+              "hyvaksyttyHarkinnanvaraisesti": false,
+              "tilankuvauksenTarkenne": "EI_TILANKUVAUKSEN_TARKENNETTA"
+            }
+          ]
+        }]
+    },
+    {
+      "_id": {
+        "$oid": "53fc79b8e4b0b0b110900765"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Hakukohde",
+      "sijoitteluajoId": {
+        "$numberLong": "1496148928094"
+      },
+      "oid": "1.2.246.562.5.72607738904",
+      "tarjoajaOid": "1.2.246.562.10.591352080610",
+      "kaikkiJonotSijoiteltu": true,
+      "valintatapajonot": [
+        {
+          "tasasijasaanto": "YLITAYTTO",
+          "oid": "14090336922663576781797489829888",
+          "nimi": "Todistusvalintajono",
+          "prioriteetti": 0,
+          "aloituspaikat": 3,
+          "eiVarasijatayttoa": false,
+          "kaikkiEhdonTayttavatHyvaksytaan": false,
+          "poissaOlevaTaytto": false,
+          "hakemukset": [
+            {
+              "hakijaOid": "1.2.246.562.24.14229104472",
+              "hakemusOid": "1.2.246.562.11.00000441369",
+              "etunimi": "Teppo",
+              "sukunimi": "Testaaja",
+              "prioriteetti": 1,
+              "jonosija": 1,
+              "pisteet": 4,
+              "tasasijaJonosija": 1,
+              "tila": "PERUUNTUNUT",
+              "hyvaksyttyHarkinnanvaraisesti": false,
+              "tilankuvauksenTarkenne": "PERUUNTUNUT_HYVAKSYTTY_YLEMMALLE_HAKUTOIVEELLE"
+            }
+          ]
+        },
+        {
+          "tasasijasaanto": "YLITAYTTO",
+          "oid": "14090336922663576781797489829881",
+          "nimi": "Koepistejono",
+          "prioriteetti": 1,
+          "aloituspaikat": 3,
+          "eiVarasijatayttoa": false,
+          "kaikkiEhdonTayttavatHyvaksytaan": false,
+          "poissaOlevaTaytto": false,
+          "hakemukset": [
+            {
+              "hakijaOid": "1.2.246.562.24.14229104472",
+              "hakemusOid": "1.2.246.562.11.00000441369",
+              "etunimi": "Teppo",
+              "sukunimi": "Testaaja",
+              "prioriteetti": 1,
+              "jonosija": 4,
+              "pisteet": 4,
+              "tasasijaJonosija": 1,
+              "tila": "PERUUNTUNUT",
+              "hyvaksyttyHarkinnanvaraisesti": false,
+              "tilankuvauksenTarkenne": "PERUUNTUNUT_HYVAKSYTTY_YLEMMALLE_HAKUTOIVEELLE"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "Valintatulos": [
+    {
+      "_id": {
+        "$oid": "53fc8613e4b0b03110900766"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Valintatulos",
+      "valintatapajonoOid": "14090336922663576781797489829885",
+      "hakemusOid": "1.2.246.562.11.00000441369",
+      "hakukohdeOid": "1.2.246.562.5.72607738903",
+      "hakijaOid": "1.2.246.562.24.14229104472",
+      "hakuOid": "1.2.246.562.5.2013080813081926341928",
+      "hakutoive": 1,
+      "tila": "KESKEN",
+      "ilmoittautumisTila": "EI_TEHTY",
+      "julkaistavissa": true
+    },
+    {
+      "_id": {
+        "$oid": "53fc8613e4b0b03110900766"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Valintatulos",
+      "valintatapajonoOid": "14090336922663576781797489829886",
+      "hakemusOid": "1.2.246.562.11.00000441369",
+      "hakukohdeOid": "1.2.246.562.5.72607738903",
+      "hakijaOid": "1.2.246.562.24.14229104472",
+      "hakuOid": "1.2.246.562.5.2013080813081926341928",
+      "hakutoive": 1,
+      "tila": "KESKEN",
+      "ilmoittautumisTila": "EI_TEHTY",
+      "julkaistavissa": false
+    },
+    {
+      "_id": {
+        "$oid": "53fc8613e4b0b03110900766"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Valintatulos",
+      "valintatapajonoOid": "14090336922663576781797489829888",
+      "hakemusOid": "1.2.246.562.11.00000441369",
+      "hakukohdeOid": "1.2.246.562.5.72607738904",
+      "hakijaOid": "1.2.246.562.24.14229104472",
+      "hakuOid": "1.2.246.562.5.2013080813081926341928",
+      "hakutoive": 3,
+      "tila": "KESKEN",
+      "ilmoittautumisTila": "EI_TEHTY",
+      "julkaistavissa": true
+    }
+  ]
+}

--- a/valinta-tulos-service/src/main/resources/fixtures/sijoittelu/ylin-toive-hyvaksytty-toisesta-jonosta-mutta-kaksi-kolmesta-julkaistua-jonoa-alemmmassa-peruuntununeessa.json
+++ b/valinta-tulos-service/src/main/resources/fixtures/sijoittelu/ylin-toive-hyvaksytty-toisesta-jonosta-mutta-kaksi-kolmesta-julkaistua-jonoa-alemmmassa-peruuntununeessa.json
@@ -1,0 +1,256 @@
+{
+  "Sijoittelu": [
+    {
+      "_id": {
+        "$oid": "547f0c17e4b0755315d44e0a"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Sijoittelu",
+      "hakuOid": "1.2.246.562.5.2013080813081926341928",
+      "sijoitteluId": {
+        "$numberLong": "1496148928094"
+      },
+      "created": {
+        "$date": "2018-06-11T13:11:51.186Z"
+      },
+      "sijoittele": true,
+      "sijoitteluajot": [
+        {
+          "sijoitteluajoId": {
+            "$numberLong": "1496148928094"
+          },
+          "hakuOid": "1.2.246.562.5.2013080813081926341928",
+          "hakukohteet": [
+            {
+              "oid": "1.2.246.562.5.72607738903"
+            },
+            {
+              "oid": "1.2.246.562.5.72607738904"
+            }
+          ],
+          "startMils": {
+            "$numberLong": "14961489280951"
+          },
+          "endMils": {
+            "$numberLong": "14961499280951"
+          }
+        }
+      ]
+    }
+  ],
+  "Hakukohde": [
+    {
+      "_id": {
+        "$oid": "53fc79b8e4b0b0b110900765"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Hakukohde",
+      "sijoitteluajoId": {
+        "$numberLong": "1496148928094"
+      },
+      "oid": "1.2.246.562.5.72607738903",
+      "tarjoajaOid": "1.2.246.562.10.591352080610",
+      "kaikkiJonotSijoiteltu": true,
+      "valintatapajonot": [
+        {
+          "tasasijasaanto": "YLITAYTTO",
+          "oid": "14090336922663576781797489829885",
+          "nimi": "Todistusvalintajono",
+          "prioriteetti": 0,
+          "aloituspaikat": 3,
+          "eiVarasijatayttoa": false,
+          "kaikkiEhdonTayttavatHyvaksytaan": false,
+          "poissaOlevaTaytto": false,
+          "hakemukset": [
+            {
+              "hakijaOid": "1.2.246.562.24.14229104472",
+              "hakemusOid": "1.2.246.562.11.00000441369",
+              "etunimi": "Teppo",
+              "sukunimi": "Testaaja",
+              "prioriteetti": 0,
+              "jonosija": 10,
+              "pisteet": 4,
+              "tasasijaJonosija": 1,
+              "tila": "VARALLA",
+              "hyvaksyttyHarkinnanvaraisesti": false,
+              "tilankuvauksenTarkenne": "EI_TILANKUVAUKSEN_TARKENNETTA"
+            }
+          ]
+        },
+        {
+          "tasasijasaanto": "YLITAYTTO",
+          "oid": "14090336922663576781797489829886",
+          "nimi": "Koepistejono",
+          "prioriteetti": 1,
+          "aloituspaikat": 3,
+          "eiVarasijatayttoa": false,
+          "kaikkiEhdonTayttavatHyvaksytaan": false,
+          "poissaOlevaTaytto": false,
+          "hakemukset": [
+            {
+              "hakijaOid": "1.2.246.562.24.14229104472",
+              "hakemusOid": "1.2.246.562.11.00000441369",
+              "etunimi": "Teppo",
+              "sukunimi": "Testaaja",
+              "prioriteetti": 0,
+              "jonosija": 1,
+              "pisteet": 4,
+              "tasasijaJonosija": 1,
+              "tila": "HYVAKSYTTY",
+              "hyvaksyttyHarkinnanvaraisesti": false,
+              "tilankuvauksenTarkenne": "EI_TILANKUVAUKSEN_TARKENNETTA"
+            }
+          ]
+        }]
+    },
+    {
+      "_id": {
+        "$oid": "53fc79b8e4b0b0b110900765"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Hakukohde",
+      "sijoitteluajoId": {
+        "$numberLong": "1496148928094"
+      },
+      "oid": "1.2.246.562.5.72607738904",
+      "tarjoajaOid": "1.2.246.562.10.591352080610",
+      "kaikkiJonotSijoiteltu": true,
+      "valintatapajonot": [
+        {
+          "tasasijasaanto": "YLITAYTTO",
+          "oid": "14090336922663576781797489829888",
+          "nimi": "Todistusvalintajono",
+          "prioriteetti": 0,
+          "aloituspaikat": 3,
+          "eiVarasijatayttoa": false,
+          "kaikkiEhdonTayttavatHyvaksytaan": false,
+          "poissaOlevaTaytto": false,
+          "hakemukset": [
+            {
+              "hakijaOid": "1.2.246.562.24.14229104472",
+              "hakemusOid": "1.2.246.562.11.00000441369",
+              "etunimi": "Teppo",
+              "sukunimi": "Testaaja",
+              "prioriteetti": 1,
+              "jonosija": 1,
+              "pisteet": 4,
+              "tasasijaJonosija": 1,
+              "tila": "PERUUNTUNUT",
+              "hyvaksyttyHarkinnanvaraisesti": false,
+              "tilankuvauksenTarkenne": "PERUUNTUNUT_HYVAKSYTTY_YLEMMALLE_HAKUTOIVEELLE"
+            }
+          ]
+        },
+        {
+          "tasasijasaanto": "YLITAYTTO",
+          "oid": "14090336922663576781797489829889",
+          "nimi": "Bonusjono",
+          "prioriteetti": 1,
+          "aloituspaikat": 4,
+          "eiVarasijatayttoa": false,
+          "kaikkiEhdonTayttavatHyvaksytaan": false,
+          "poissaOlevaTaytto": false,
+          "hakemukset": [
+            {
+              "hakijaOid": "1.2.246.562.24.14229104472",
+              "hakemusOid": "1.2.246.562.11.00000441369",
+              "etunimi": "Teppo",
+              "sukunimi": "Testaaja",
+              "prioriteetti": 2,
+              "jonosija": 4,
+              "pisteet": 4,
+              "tasasijaJonosija": 1,
+              "tila": "PERUUNTUNUT",
+              "hyvaksyttyHarkinnanvaraisesti": false,
+              "tilankuvauksenTarkenne": "PERUUNTUNUT_HYVAKSYTTY_YLEMMALLE_HAKUTOIVEELLE"
+            }
+          ]
+        },
+        {
+          "tasasijasaanto": "YLITAYTTO",
+          "oid": "14090336922663576781797489829881",
+          "nimi": "Koepistejono",
+          "prioriteetti": 2,
+          "aloituspaikat": 3,
+          "eiVarasijatayttoa": false,
+          "kaikkiEhdonTayttavatHyvaksytaan": false,
+          "poissaOlevaTaytto": false,
+          "hakemukset": [
+            {
+              "hakijaOid": "1.2.246.562.24.14229104472",
+              "hakemusOid": "1.2.246.562.11.00000441369",
+              "etunimi": "Teppo",
+              "sukunimi": "Testaaja",
+              "prioriteetti": 1,
+              "jonosija": 4,
+              "pisteet": 4,
+              "tasasijaJonosija": 1,
+              "tila": "PERUUNTUNUT",
+              "hyvaksyttyHarkinnanvaraisesti": false,
+              "tilankuvauksenTarkenne": "PERUUNTUNUT_HYVAKSYTTY_YLEMMALLE_HAKUTOIVEELLE"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "Valintatulos": [
+    {
+      "_id": {
+        "$oid": "53fc8613e4b0b03110900764"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Valintatulos",
+      "valintatapajonoOid": "14090336922663576781797489829885",
+      "hakemusOid": "1.2.246.562.11.00000441369",
+      "hakukohdeOid": "1.2.246.562.5.72607738903",
+      "hakijaOid": "1.2.246.562.24.14229104472",
+      "hakuOid": "1.2.246.562.5.2013080813081926341928",
+      "hakutoive": 1,
+      "tila": "KESKEN",
+      "ilmoittautumisTila": "EI_TEHTY",
+      "julkaistavissa": true
+    },
+    {
+      "_id": {
+        "$oid": "53fc8613e4b0b03110900765"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Valintatulos",
+      "valintatapajonoOid": "14090336922663576781797489829886",
+      "hakemusOid": "1.2.246.562.11.00000441369",
+      "hakukohdeOid": "1.2.246.562.5.72607738903",
+      "hakijaOid": "1.2.246.562.24.14229104472",
+      "hakuOid": "1.2.246.562.5.2013080813081926341928",
+      "hakutoive": 1,
+      "tila": "KESKEN",
+      "ilmoittautumisTila": "EI_TEHTY",
+      "julkaistavissa": false
+    },
+    {
+      "_id": {
+        "$oid": "53fc8613e4b0b03110900766"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Valintatulos",
+      "valintatapajonoOid": "14090336922663576781797489829888",
+      "hakemusOid": "1.2.246.562.11.00000441369",
+      "hakukohdeOid": "1.2.246.562.5.72607738904",
+      "hakijaOid": "1.2.246.562.24.14229104472",
+      "hakuOid": "1.2.246.562.5.2013080813081926341928",
+      "hakutoive": 3,
+      "tila": "KESKEN",
+      "ilmoittautumisTila": "EI_TEHTY",
+      "julkaistavissa": true
+    },
+    {
+      "_id": {
+        "$oid": "53fc8613e4b0b03110900767"
+      },
+      "className": "fi.vm.sade.sijoittelu.domain.Valintatulos",
+      "valintatapajonoOid": "14090336922663576781797489829889",
+      "hakemusOid": "1.2.246.562.11.00000441369",
+      "hakukohdeOid": "1.2.246.562.5.72607738904",
+      "hakijaOid": "1.2.246.562.24.14229104472",
+      "hakuOid": "1.2.246.562.5.2013080813081926341928",
+      "hakutoive": 3,
+      "tila": "KESKEN",
+      "ilmoittautumisTila": "EI_TEHTY",
+      "julkaistavissa": true
+    }
+  ]
+}

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
@@ -882,12 +882,12 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
     tuloksetWithIndex.map {
       case (tulos, index) =>
         val higherJulkaisematon = firstJulkaisematon >= 0 && index > firstJulkaisematon
-        if (higherJulkaisematon && tulos.valintatila == Valintatila.peruuntunut) {
+        if (higherJulkaisematon && List(Valintatila.peruuntunut, Valintatila.kesken).contains(tulos.valintatila)) {
           val jonoJostaOliHyvaksyttyJulkaistu: Option[ValintatapajonoOid] = valinnantulosRepository.getViimeisinValinnantilaMuutosHyvaksyttyJaJulkaistuJonoOidHistoriasta(hakemusOid, tulos.hakukohdeOid)
           val wasHyvaksyttyJulkaistu = jonoJostaOliHyvaksyttyJulkaistu.nonEmpty
           val existsHigherHyvaksyttyJulkaistu = tuloksetWithIndex.exists(twi => twi._2 < index && twi._1.valintatila.equals(Valintatila.hyväksytty) && twi._1.julkaistavissa)
           if (wasHyvaksyttyJulkaistu && !existsHigherHyvaksyttyJulkaistu && !firstChanged) {
-            logger.info("Merkitään aiemmin hyväksyttynä ollut peruuntunut hyväksytyksi koska ylemmän hakutoiveen tuloksia ei ole vielä julkaistu. Index {}, tulos {}", index, tulos)
+            logger.info(s"Merkitään aiemmin hyväksyttynä ollut ${tulos.valintatila} hyväksytyksi koska ylemmän hakutoiveen tuloksia ei ole vielä julkaistu. Index {}, tulos {}", index, tulos)
             firstChanged = true
             tulos.copy(
               valintatila = Valintatila.hyväksytty,

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
@@ -838,10 +838,18 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
     }
   }
 
+  private def onJulkaisematontaAlempiaPeruuntuneitaTaiKeskeneräisiä(ylimmänJulkaisemattomanIndeksi: Int,
+                                                                    tulos: Hakutoiveentulos,
+                                                                    hakutoiveenIndeksi: Int): Boolean = {
+    ylimmänJulkaisemattomanIndeksi >= 0 &&
+      hakutoiveenIndeksi > ylimmänJulkaisemattomanIndeksi &&
+      tulos.valintatila == Valintatila.peruuntunut
+  }
+
   private def näytäJulkaisematontaAlemmatPeruuntuneetKeskeneräisinä(hakemusOid: HakemusOid, tulokset: List[Hakutoiveentulos], haku: Haku, ohjausparametrit: Ohjausparametrit) = {
     val firstJulkaisematon: Int = tulokset.indexWhere (!_.julkaistavissa)
     tulokset.zipWithIndex.map {
-      case (tulos, index) if firstJulkaisematon >= 0 && index > firstJulkaisematon && tulos.valintatila == Valintatila.peruuntunut =>
+      case (tulos, index) if onJulkaisematontaAlempiaPeruuntuneitaTaiKeskeneräisiä(firstJulkaisematon, tulos, index) =>
         logger.debug("näytäJulkaisematontaAlemmatPeruuntuneetKeskeneräisinä toKesken {}", index)
         tulos.
           toKesken.

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
@@ -838,12 +838,20 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
     }
   }
 
+  /**
+   * Jos kaikki jonot eivät ole vielä sijoittelussa, SijoittelutulosService.jononValintatila asettaa
+   * hakutoiveen tilaksi "kesken", mutta jättää jonokohtaiset tulostiedot paikalleen. Koska jonokohtaisia
+   * tulostietoja joistakin muista tiloista voidaan haluta näyttää, ei siivota niitä vielä siellä, vaan
+   * vasta tapauskohtaisesti täällä.
+   *
+   * @see [[fi.vm.sade.valintatulosservice.sijoittelu.SijoittelutulosService.jononValintatila]]
+   */
   private def onJulkaisematontaAlempiaPeruuntuneitaTaiKeskeneräisiä(ylimmänJulkaisemattomanIndeksi: Int,
                                                                     tulos: Hakutoiveentulos,
                                                                     hakutoiveenIndeksi: Int): Boolean = {
     ylimmänJulkaisemattomanIndeksi >= 0 &&
       hakutoiveenIndeksi > ylimmänJulkaisemattomanIndeksi &&
-      tulos.valintatila == Valintatila.peruuntunut
+      List(Valintatila.peruuntunut, Valintatila.kesken).contains(tulos.valintatila)
   }
 
   private def näytäJulkaisematontaAlemmatPeruuntuneetKeskeneräisinä(hakemusOid: HakemusOid, tulokset: List[Hakutoiveentulos], haku: Haku, ohjausparametrit: Ohjausparametrit) = {

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/SijoittelutulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/sijoittelu/SijoittelutulosService.scala
@@ -166,43 +166,43 @@ class SijoittelutulosService(raportointiService: ValintarekisteriRaportointiServ
 
     val hakutoiveidenYhteenvedot = hakija.getHakutoiveet.toList.map { hakutoive: HakutoiveDTO =>
       val vastaanotto = vastaanottoRecords.find(v => v.hakukohdeOid.toString == hakutoive.getHakukohdeOid)
-      val jonot = JonoFinder.järjestäJonotPrioriteetinMukaan(hakutoive)
-      val jono = jonot.headOption.get
-      val valintatila = jononValintatila(jono, hakutoive)
+      val jonotLaskevassaPrioriteettijärjestyksessä = JonoFinder.järjestäJonotPrioriteetinMukaan(hakutoive)
+      val ylimmänPrioriteetinJono = jonotLaskevassaPrioriteettijärjestyksessä.headOption.get
+      val valintatila = jononValintatila(ylimmänPrioriteetinJono, hakutoive)
 
       val hakutoiveenHyvaksyttyJaJulkaistuDate = hyvaksyttyJulkaistuDates.get(HakukohdeOid(hakutoive.getHakukohdeOid))
 
       val (hakijanTilat, vastaanottoDeadline) = tilatietoJaVastaanottoDeadline(valintatila, vastaanotto, ohjausparametrit, hakutoiveenHyvaksyttyJaJulkaistuDate, vastaanotettavuusVirkailijana)
       val (virkailijanTilat, _) = tilatietoJaVastaanottoDeadline(valintatila, vastaanotto, ohjausparametrit, hakutoiveenHyvaksyttyJaJulkaistuDate, true)
 
-      val hyväksyttyJulkaistussaJonossa = Valintatila.isHyväksytty(valintatila) && jono.isJulkaistavissa
+      val hyväksyttyJulkaistussaJonossa = Valintatila.isHyväksytty(valintatila) && ylimmänPrioriteetinJono.isJulkaistavissa
       val julkaistavissa = hyväksyttyJulkaistussaJonossa || kaikkiJonotJulkaistu(hakutoive)
-      val pisteet: Option[BigDecimal] = Option(jono.getPisteet).map((p: java.math.BigDecimal) => new BigDecimal(p))
+      val pisteet: Option[BigDecimal] = Option(ylimmänPrioriteetinJono.getPisteet).map((p: java.math.BigDecimal) => new BigDecimal(p))
 
       HakutoiveenSijoitteluntulos(
         HakukohdeOid(hakutoive.getHakukohdeOid),
         hakutoive.getTarjoajaOid,
-        ValintatapajonoOid(jono.getValintatapajonoOid),
+        ValintatapajonoOid(ylimmänPrioriteetinJono.getValintatapajonoOid),
         hakijanTilat = hakijanTilat,
         virkailijanTilat = virkailijanTilat,
         vastaanottoDeadline.map(_.toDate),
-        SijoitteluajonIlmoittautumistila(Option(jono.getIlmoittautumisTila).getOrElse(IlmoittautumisTila.EI_TEHTY)),
-        viimeisinHakemuksenTilanMuutos = Option(jono.getHakemuksenTilanViimeisinMuutos),
-        viimeisinValintatuloksenMuutos = Option(jono.getValintatuloksenViimeisinMuutos),
-        Option(jono.getJonosija).map(_.toInt),
-        Option(jono.getVarasijojaKaytetaanAlkaen),
-        Option(jono.getVarasijojaTaytetaanAsti),
-        Option(jono.getVarasijanNumero).map(_.toInt),
+        SijoitteluajonIlmoittautumistila(Option(ylimmänPrioriteetinJono.getIlmoittautumisTila).getOrElse(IlmoittautumisTila.EI_TEHTY)),
+        viimeisinHakemuksenTilanMuutos = Option(ylimmänPrioriteetinJono.getHakemuksenTilanViimeisinMuutos),
+        viimeisinValintatuloksenMuutos = Option(ylimmänPrioriteetinJono.getValintatuloksenViimeisinMuutos),
+        Option(ylimmänPrioriteetinJono.getJonosija).map(_.toInt),
+        Option(ylimmänPrioriteetinJono.getVarasijojaKaytetaanAlkaen),
+        Option(ylimmänPrioriteetinJono.getVarasijojaTaytetaanAsti),
+        Option(ylimmänPrioriteetinJono.getVarasijanNumero).map(_.toInt),
         julkaistavissa,
-        ehdollisestiHyvaksyttavissa = jono.isEhdollisestiHyvaksyttavissa,
-        ehdollisenHyvaksymisenEhtoKoodi = Option(jono.getEhdollisenHyvaksymisenEhtoKoodi),
-        ehdollisenHyvaksymisenEhtoFI = Option(jono.getEhdollisenHyvaksymisenEhtoFI),
-        ehdollisenHyvaksymisenEhtoSV = Option(jono.getEhdollisenHyvaksymisenEhtoSV),
-        ehdollisenHyvaksymisenEhtoEN = Option(jono.getEhdollisenHyvaksymisenEhtoEN),
-        (if (fromHakemuksenTila(jono.getTila) == Valintatila.hylätty) {
-          jonot.last.getTilanKuvaukset
+        ehdollisestiHyvaksyttavissa = ylimmänPrioriteetinJono.isEhdollisestiHyvaksyttavissa,
+        ehdollisenHyvaksymisenEhtoKoodi = Option(ylimmänPrioriteetinJono.getEhdollisenHyvaksymisenEhtoKoodi),
+        ehdollisenHyvaksymisenEhtoFI = Option(ylimmänPrioriteetinJono.getEhdollisenHyvaksymisenEhtoFI),
+        ehdollisenHyvaksymisenEhtoSV = Option(ylimmänPrioriteetinJono.getEhdollisenHyvaksymisenEhtoSV),
+        ehdollisenHyvaksymisenEhtoEN = Option(ylimmänPrioriteetinJono.getEhdollisenHyvaksymisenEhtoEN),
+        (if (fromHakemuksenTila(ylimmänPrioriteetinJono.getTila) == Valintatila.hylätty) {
+          jonotLaskevassaPrioriteettijärjestyksessä.last.getTilanKuvaukset
         } else {
-          jono.getTilanKuvaukset
+          ylimmänPrioriteetinJono.getTilanKuvaukset
         }).toMap,
         pisteet,
         jonokohtaisetTulostiedot = hakutoive
@@ -216,7 +216,7 @@ class SijoittelutulosService(raportointiService: ValintarekisteriRaportointiServ
               valintatila = vastaanottotilanVaikutusValintatilaan(
                 hakemuksenTilastaJononValintatilaksi(valintatapajono),
                 hakijanTilat.vastaanottotila,
-                Some(jono),
+                Some(ylimmänPrioriteetinJono),
                 Some(valintatapajono)
               ),
               julkaistavissa = valintatapajono.isJulkaistavissa,
@@ -229,8 +229,8 @@ class SijoittelutulosService(raportointiService: ValintarekisteriRaportointiServ
                 EN = Option(valintatapajono.getEhdollisenHyvaksymisenEhtoEN)
               )),
               varasijanumero = Option(valintatapajono.getVarasijanNumero).map {_.toInt},
-              eiVarasijatayttoa = jono.isEiVarasijatayttoa,
-              varasijat = Option(jono.getVarasijat).map(_.toInt).filter(_ != 0)
+              eiVarasijatayttoa = ylimmänPrioriteetinJono.isEiVarasijatayttoa,
+              varasijat = Option(ylimmänPrioriteetinJono.getVarasijat).map(_.toInt).filter(_ != 0)
             )
           })
           .toList

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
@@ -636,8 +636,8 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
           hakemusFixtures = List( "00000441369-3"),
           ohjausparametritFixture =  "varasijasaannot-ei-viela-voimassa")
 
-        val alemmanToiveenYlemmanHyvaksytynJononOid = ValintatapajonoOid("14090336922663576781797489829888")
-        val alemmanToiveenAlemmanHyvaksytynJononOid = ValintatapajonoOid("14090336922663576781797489829889")
+        val alemmanToiveenEnsimmäisenHyväksytynJononOid = ValintatapajonoOid("14090336922663576781797489829888")
+        val alemmanToiveenToisenHyväksytynJononOid = ValintatapajonoOid("14090336922663576781797489829889")
         val alempiToiveOid = HakukohdeOid("1.2.246.562.5.72607738904")
         val hakijaOid = "1.2.246.562.24.14229104472"
 
@@ -645,33 +645,33 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
           valintarekisteriDb.storeValinnantila(
             ValinnantilanTallennus(
               hakemusOid,
-              alemmanToiveenYlemmanHyvaksytynJononOid,
+              alemmanToiveenEnsimmäisenHyväksytynJononOid,
               alempiToiveOid,
               hakijaOid,
               Hyvaksytty,
               "testi")).
             andThen(
-              asetaJulkaistavissa(alempiToiveOid, alemmanToiveenYlemmanHyvaksytynJononOid, hakemusOid, julkaistavissa = true)).
+              asetaJulkaistavissa(alempiToiveOid, alemmanToiveenEnsimmäisenHyväksytynJononOid, hakemusOid, julkaistavissa = true)).
             andThen(
-              asetaJulkaistavissa(alempiToiveOid, alemmanToiveenAlemmanHyvaksytynJononOid, hakemusOid, julkaistavissa = true)))
+              asetaJulkaistavissa(alempiToiveOid, alemmanToiveenToisenHyväksytynJononOid, hakemusOid, julkaistavissa = true)))
 
         valintarekisteriDb.runBlocking(
           valintarekisteriDb.storeValinnantila(
             ValinnantilanTallennus(
               hakemusOid,
-              alemmanToiveenYlemmanHyvaksytynJononOid,
+              alemmanToiveenEnsimmäisenHyväksytynJononOid,
               alempiToiveOid,
               hakijaOid,
               Peruuntunut,
               "testi")).
             andThen(tallennaTilankuvauksenTarkenne(
               alempiToiveOid,
-              alemmanToiveenYlemmanHyvaksytynJononOid,
+              alemmanToiveenEnsimmäisenHyväksytynJononOid,
               hakemusOid,
               PeruuntunutHyvaksyttyYlemmalleHakutoiveelle.tilankuvauksenTarkenne)).
             andThen(tallennaTilankuvauksenTarkenne(
               alempiToiveOid,
-              alemmanToiveenAlemmanHyvaksytynJononOid,
+              alemmanToiveenToisenHyväksytynJononOid,
               hakemusOid,
               PeruuntunutHyvaksyttyYlemmalleHakutoiveelle.tilankuvauksenTarkenne)))
 

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
@@ -498,7 +498,7 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
         checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738904"), Valintatila.peruuntunut, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
       }
 
-      "ylimmällä toivella julkaistu varalla ja julkaisematon hyväksytty, alempi hyväksytty mutta kaikki jonot ei sijoittelussa -> näytetään alempi kesken" in {
+      "ylimmällä toiveella julkaistu varalla ja julkaisematon hyväksytty, alempi hyväksytty mutta kaikki jonot ei sijoittelussa -> näytetään alempi kesken" in {
         useFixture("ylin-toive-hyvaksytty-toisesta-jonosta-mutta-julkaisematon-alempi-peruuntunut.json",
           hakuFixture = hakuFixture,
           hakemusFixtures = List( "00000441369-3"),
@@ -532,7 +532,7 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
         alemmanToiveenTulos.jonokohtaisetTulostiedot(1).tilanKuvaukset must beNone
       }
 
-      "ylimmällä toivella julkaistu varalla ja julkaisematon hyväksytty, alempi julkaistu hyväksytty mutta kaikki jonot ei sijoittelussa -> näytetään alempi hyväksytty, odottaa ylempiä" in {
+      "ylimmällä toiveella julkaistu varalla ja julkaisematon hyväksytty, alempi julkaistu hyväksytty mutta kaikki jonot ei sijoittelussa -> näytetään alempi hyväksytty, odottaa ylempiä" in {
         useFixture("ylin-toive-hyvaksytty-toisesta-jonosta-mutta-julkaisematon-alempi-peruuntunut.json",
           hakuFixture = hakuFixture,
           hakemusFixtures = List( "00000441369-3"),
@@ -601,7 +601,7 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
         alemmanToiveenTulos.jonokohtaisetTulostiedot(1).tilanKuvaukset must beNone
       }
 
-      "ylimmällä toivella julkaistu varalla ja julkaisematon hyväksytty, alempana kaksi julkaistua hyväksyttyä mutta kaikki jonot ei sijoittelussa -> " +
+      "ylimmällä toiveella julkaistu varalla ja julkaisematon hyväksytty, alempana kaksi julkaistua hyväksyttyä mutta kaikki jonot ei sijoittelussa -> " +
         "näytetään alempi hyväksytty, odottaa ylempiä ja peruuntunut, hyväksytty toisessa valintatapajonossa" in {
         useFixture("ylin-toive-hyvaksytty-toisesta-jonosta-mutta-kaksi-kolmesta-julkaistua-jonoa-alemmmassa-peruuntununeessa.json",
           hakuFixture = hakuFixture,

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
@@ -497,6 +497,40 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
         checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738903"), Valintatila.peruuntunut, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
         checkHakutoiveState(getHakutoive("1.2.246.562.5.72607738904"), Valintatila.peruuntunut, Vastaanottotila.kesken, Vastaanotettavuustila.ei_vastaanotettavissa, false)
       }
+
+      "ylimmällä toivella julkaistu varalla ja julkaisematon hyväksytty, alempi hyväksytty mutta kaikki jonot ei sijoittelussa -> näytetään alempi kesken" in {
+        useFixture("ylin-toive-hyvaksytty-toisesta-jonosta-mutta-julkaisematon-alempi-peruuntunut.json",
+          hakuFixture = hakuFixture,
+          hakemusFixtures = List( "00000441369-3"),
+          ohjausparametritFixture =  "varasijasaannot-ei-viela-voimassa")
+
+        val ylemmanToiveenTulos = getHakutoive("1.2.246.562.5.72607738903")
+        checkHakutoiveState(
+          ylemmanToiveenTulos,
+          Valintatila.kesken,
+          Vastaanottotila.kesken,
+          Vastaanotettavuustila.ei_vastaanotettavissa,
+          julkaistavissa = false)
+
+        ylemmanToiveenTulos.jonokohtaisetTulostiedot.size must_== 2
+        ylemmanToiveenTulos.jonokohtaisetTulostiedot.head.valintatila must_== Valintatila.varalla
+        ylemmanToiveenTulos.jonokohtaisetTulostiedot.head.tilanKuvaukset must beSome(Map())
+        ylemmanToiveenTulos.jonokohtaisetTulostiedot(1).valintatila must_== Valintatila.kesken
+        ylemmanToiveenTulos.jonokohtaisetTulostiedot(1).tilanKuvaukset must beNone
+
+        val alemmanToiveenTulos = getHakutoive("1.2.246.562.5.72607738904")
+        checkHakutoiveState(
+          alemmanToiveenTulos,
+          Valintatila.kesken,
+          Vastaanottotila.kesken,
+          Vastaanotettavuustila.ei_vastaanotettavissa,
+          julkaistavissa = false)
+        alemmanToiveenTulos.jonokohtaisetTulostiedot.size must_== 2
+        alemmanToiveenTulos.jonokohtaisetTulostiedot.head.valintatila must_== Valintatila.kesken
+        alemmanToiveenTulos.jonokohtaisetTulostiedot.head.tilanKuvaukset must beNone
+        alemmanToiveenTulos.jonokohtaisetTulostiedot(1).valintatila must_== Valintatila.kesken
+        alemmanToiveenTulos.jonokohtaisetTulostiedot(1).tilanKuvaukset must beNone
+      }
     }
 
     "peruuntunut, sijoittelua käyttävä korkeakouluhaku" in {

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
@@ -531,6 +531,75 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
         alemmanToiveenTulos.jonokohtaisetTulostiedot(1).valintatila must_== Valintatila.kesken
         alemmanToiveenTulos.jonokohtaisetTulostiedot(1).tilanKuvaukset must beNone
       }
+
+      "ylimmällä toivella julkaistu varalla ja julkaisematon hyväksytty, alempi julkaistu hyväksytty mutta kaikki jonot ei sijoittelussa -> näytetään alempi hyväksytty, odottaa ylempiä" in {
+        useFixture("ylin-toive-hyvaksytty-toisesta-jonosta-mutta-julkaisematon-alempi-peruuntunut.json",
+          hakuFixture = hakuFixture,
+          hakemusFixtures = List( "00000441369-3"),
+          ohjausparametritFixture =  "varasijasaannot-ei-viela-voimassa")
+
+        val alemmanToiveenHyvaksytynJononOid = ValintatapajonoOid("14090336922663576781797489829888")
+        val alempiToiveOid = HakukohdeOid("1.2.246.562.5.72607738904")
+        val hakijaOid = "1.2.246.562.24.14229104472"
+
+        valintarekisteriDb.runBlocking(
+          valintarekisteriDb.storeValinnantila(
+            ValinnantilanTallennus(
+              hakemusOid,
+              alemmanToiveenHyvaksytynJononOid,
+              alempiToiveOid,
+              hakijaOid,
+              Hyvaksytty,
+              "testi")).
+            andThen(
+              sqlu"""update valinnantulokset set julkaistavissa = 'true'
+                 where
+                   hakukohde_oid = ${alempiToiveOid.s}
+                   and valintatapajono_oid = ${alemmanToiveenHyvaksytynJononOid.s}
+                   and hakemus_oid = ${hakemusOid.s}"""))
+
+        valintarekisteriDb.runBlocking(
+          valintarekisteriDb.storeValinnantila(
+            ValinnantilanTallennus(
+              hakemusOid,
+              alemmanToiveenHyvaksytynJononOid,
+              alempiToiveOid,
+              hakijaOid,
+              Peruuntunut,
+              "testi")).
+            andThen(tallennaTilankuvauksenTarkenne(
+              alempiToiveOid,
+              alemmanToiveenHyvaksytynJononOid,
+              hakemusOid,
+              PeruuntunutHyvaksyttyYlemmalleHakutoiveelle.tilankuvauksenTarkenne)))
+
+        val ylemmanToiveenTulos = getHakutoive("1.2.246.562.5.72607738903")
+        checkHakutoiveState(
+          ylemmanToiveenTulos,
+          Valintatila.kesken,
+          Vastaanottotila.kesken,
+          Vastaanotettavuustila.ei_vastaanotettavissa,
+          julkaistavissa = false)
+
+        ylemmanToiveenTulos.jonokohtaisetTulostiedot.size must_== 2
+        ylemmanToiveenTulos.jonokohtaisetTulostiedot.head.valintatila must_== Valintatila.varalla
+        ylemmanToiveenTulos.jonokohtaisetTulostiedot.head.tilanKuvaukset must beSome(Map())
+        ylemmanToiveenTulos.jonokohtaisetTulostiedot(1).valintatila must_== Valintatila.kesken
+        ylemmanToiveenTulos.jonokohtaisetTulostiedot(1).tilanKuvaukset must beNone
+
+        val alemmanToiveenTulos = getHakutoive("1.2.246.562.5.72607738904")
+        checkHakutoiveState(
+          alemmanToiveenTulos,
+          Valintatila.hyväksytty,
+          Vastaanottotila.kesken,
+          Vastaanotettavuustila.ei_vastaanotettavissa,
+          julkaistavissa = false)
+        alemmanToiveenTulos.jonokohtaisetTulostiedot.size must_== 2
+        alemmanToiveenTulos.jonokohtaisetTulostiedot.head.valintatila must_== Valintatila.hyväksytty
+        alemmanToiveenTulos.jonokohtaisetTulostiedot.head.tilanKuvaukset must beNone
+        alemmanToiveenTulos.jonokohtaisetTulostiedot(1).valintatila must_== Valintatila.kesken
+        alemmanToiveenTulos.jonokohtaisetTulostiedot(1).tilanKuvaukset must beNone
+      }
     }
 
     "peruuntunut, sijoittelua käyttävä korkeakouluhaku" in {


### PR DESCRIPTION
Jos on 
* ylempi hyväksytty julkaisematon hakutoive
* alempi hyväksytty julkaistu hakutoive (joka peruuntuu ylemmän vaikutuksesta)
* ja alemmalla toiveella on vielä sijoittelemattomia jonoja

niin alempi toive asetettiin aiemmassa vaiheessa kesken-tilaiseksi, jolloin peruuntunut-tilaiset jonokohtaiset tulostiedot jäivät siivoamatta.