### PR TITLE
VTKU-189 : Tehokkaampi ja ehkä oikeampi kysely

### DIFF
--- a/valinta-tulos-valintarekisteri-db/src/main/resources/db/migration-vts/V202007061149__valinnantilat_history_index.sql
+++ b/valinta-tulos-valintarekisteri-db/src/main/resources/db/migration-vts/V202007061149__valinnantilat_history_index.sql
@@ -1,0 +1,1 @@
+create index if not exists valinnantilat_history_hakukohde_hakemus_tila_idx on valinnantilat_history(hakemus_oid, hakemus_oid, tila);

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/impl/ValinnantulosRepositoryImpl.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/impl/ValinnantulosRepositoryImpl.scala
@@ -69,9 +69,9 @@ trait ValinnantulosRepositoryImpl extends ValinnantulosRepository with Valintare
         and vth.transaction_id = (
                 select max(vths.transaction_id)
                 from valinnantilat_history as vths
-                where vths.hakemus_oid = ${hakemusOid}
-                  and vths.hakukohde_oid = ${hakukohdeOid}
-                limit 1
+                where vths.hakemus_oid = vth.hakemus_oid
+                  and vths.hakukohde_oid = vth.hakukohde_oid
+                  and vths.tila = vth.tila
         )
         and ((
                 select true

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/impl/ValinnantulosRepositoryImpl.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/impl/ValinnantulosRepositoryImpl.scala
@@ -76,8 +76,8 @@ trait ValinnantulosRepositoryImpl extends ValinnantulosRepository with Valintare
         and ((
                 select true
                 from valinnantulokset as t
-                where t.hakemus_oid = ${hakemusOid}
-                  and t.hakukohde_oid = ${hakukohdeOid}
+                where t.hakemus_oid = vth.hakemus_oid
+                  and t.hakukohde_oid = vth.hakukohde_oid
                   and t.valintatapajono_oid = vth.valintatapajono_oid
                   and t.julkaistavissa = 'true'
                   and lower(t.system_time) <@ vth.system_time
@@ -85,8 +85,8 @@ trait ValinnantulosRepositoryImpl extends ValinnantulosRepository with Valintare
             or (
                 select true
                 from valinnantulokset_history as th
-                where th.hakemus_oid = ${hakemusOid}
-                  and th.hakukohde_oid = ${hakukohdeOid}
+                where th.hakemus_oid = vth.hakemus_oid
+                  and th.hakukohde_oid = vth.hakukohde_oid
                   and th.valintatapajono_oid = vth.valintatapajono_oid
                   and th.julkaistavissa = 'true'
                   and th.system_time && vth.system_time


### PR DESCRIPTION
Vanha kyselyversio näytti aiheuttavan full table scanin isoon
valinnantilat_history-tauluun.

Tuntui myös epäilyttävältä, että siinä tarkistetiin, että hyväksytyn
transaktioid olisi koko hakukohteen kaikkien tilamuutosten
transaktio-id:iden maksimi. Luulisi, että siinä pitäisi etsiä uusimman
samasta jonosta hyväksytty-tilaisen muutoksen transaktio-id.

Lisäksi siinä oli nähdäkseni turhaan limit 1 (ei kai maksimista tule
koskaan kuin yksi arvo).