### PR TITLE
VTKU-40 : sijoittelun tekemä vastaanottojen tallennus hidas

### DIFF
--- a/valinta-tulos-service/src/main/scala/ScalatraBootstrap.scala
+++ b/valinta-tulos-service/src/main/scala/ScalatraBootstrap.scala
@@ -81,7 +81,7 @@ class ScalatraBootstrap extends LifeCycle with Logging {
     lazy val hakemusRepository = new HakemusRepository(hakuAppRepository, ataruHakemusRepository, ataruHakemusTarjontaEnricher)
     lazy val valintatulosService = new ValintatulosService(valintarekisteriDb, sijoittelutulosService, hakemusRepository, valintarekisteriDb, hakuService, valintarekisteriDb, hakukohdeRecordService, valintatulosDao)(appConfig)
     lazy val streamingValintatulosService = new StreamingValintatulosService(valintatulosService, valintarekisteriDb, hakijaDTOClient)(appConfig)
-    lazy val vastaanottoService = new VastaanottoService(hakuService, hakukohdeRecordService, valintatulosService, valintarekisteriDb, appConfig.ohjausparametritService, sijoittelutulosService, hakemusRepository, valintarekisteriDb)
+    lazy val vastaanottoService = new VastaanottoService(hakuService, hakukohdeRecordService, valintatulosService, valintarekisteriDb, valintarekisteriDb, appConfig.ohjausparametritService, sijoittelutulosService, hakemusRepository, valintarekisteriDb)
     lazy val ilmoittautumisService = new IlmoittautumisService(valintatulosService, valintarekisteriDb, valintarekisteriDb)
 
     lazy val authorizer = new OrganizationHierarchyAuthorizer(appConfig)

--- a/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
+++ b/valinta-tulos-service/src/main/scala/fi/vm/sade/valintatulosservice/ValintatulosService.scala
@@ -229,8 +229,11 @@ class ValintatulosService(valinnantulosRepository: ValinnantulosRepository,
     valintatulokset
   }
 
-  def findValintaTuloksetForVirkailija(hakuOid: HakuOid, hakukohdeOid: HakukohdeOid): List[Valintatulos] = {
-    val haunVastaanotot: Map[String, Set[VastaanottoRecord]] = virkailijaVastaanottoRepository.findHaunVastaanotot(hakuOid).groupBy(_.henkiloOid)
+  def findValintaTuloksetForVirkailija(hakuOid: HakuOid,
+                                       hakukohdeOid: HakukohdeOid,
+                                       haunVastaanototHakijoittain: Option[Map[String, Set[VastaanottoRecord]]] = None
+                                      ): List[Valintatulos] = {
+    val haunVastaanotot: Map[String, Set[VastaanottoRecord]] = haunVastaanototHakijoittain.getOrElse(virkailijaVastaanottoRepository.findHaunVastaanotot(hakuOid).groupBy(_.henkiloOid))
     val hakemustenTulokset: Iterator[Hakemuksentulos] = hakemustenTulosByHakukohde(hakuOid, hakukohdeOid, Some(haunVastaanotot)) match {
       case Right(x) => x
       case Left(e) => throw e

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValinnantulosServiceVastaanottoSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValinnantulosServiceVastaanottoSpec.scala
@@ -422,8 +422,7 @@ class ValinnantulosServiceVastaanottoSpec extends ITSpecification with TimeWarp 
   lazy val hakemusRepository = new HakemusRepository(new HakuAppRepository(), new AtaruHakemusRepository(appConfig), new AtaruHakemusEnricher(appConfig, hakuService, oppijanumerorekisteriService))
   lazy val valintatulosService = new ValintatulosService(valintarekisteriDb, sijoittelutulosService, hakemusRepository, valintarekisteriDb,
     hakuService, valintarekisteriDb, hakukohdeRecordService, valintatulosDao)(appConfig)
-  lazy val vastaanottoService = new VastaanottoService(hakuService, hakukohdeRecordService, valintatulosService,
-    valintarekisteriDb, appConfig.ohjausparametritService, sijoittelutulosService, hakemusRepository, valintarekisteriDb)
+  lazy val vastaanottoService = new VastaanottoService(hakuService, hakukohdeRecordService, valintatulosService, valintarekisteriDb, valintarekisteriDb, appConfig.ohjausparametritService, sijoittelutulosService, hakemusRepository, valintarekisteriDb)
   lazy val ilmoittautumisService = new IlmoittautumisService(valintatulosService,
     valintarekisteriDb, valintarekisteriDb)
   lazy val yhdenPaikanSaannos = new YhdenPaikanSaannos(hakuService, valintarekisteriDb)

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/VastaanottoServiceHakijanaSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/VastaanottoServiceHakijanaSpec.scala
@@ -519,8 +519,7 @@ class VastaanottoServiceHakijanaSpec extends ITSpecification with TimeWarp with 
   lazy val hakemusRepository = new HakemusRepository(new HakuAppRepository(), new AtaruHakemusRepository(appConfig), new AtaruHakemusEnricher(appConfig, hakuService, oppijanumerorekisteriService))
   lazy val valintatulosService = new ValintatulosService(valintarekisteriDb, sijoittelutulosService, hakemusRepository, valintarekisteriDb,
     hakuService, valintarekisteriDb, hakukohdeRecordService, valintatulosDao)
-  lazy val vastaanottoService = new VastaanottoService(hakuService, hakukohdeRecordService, valintatulosService,
-    valintarekisteriDb, appConfig.ohjausparametritService, sijoittelutulosService, hakemusRepository, valintarekisteriDb)
+  lazy val vastaanottoService = new VastaanottoService(hakuService, hakukohdeRecordService, valintatulosService, valintarekisteriDb, valintarekisteriDb, appConfig.ohjausparametritService, sijoittelutulosService, hakemusRepository, valintarekisteriDb)
   lazy val ilmoittautumisService = new IlmoittautumisService(valintatulosService,
     valintarekisteriDb, valintarekisteriDb)
 

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/VastaanottoServiceVirkailijanaSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/VastaanottoServiceVirkailijanaSpec.scala
@@ -416,8 +416,7 @@ class VastaanottoServiceVirkailijanaSpec extends ITSpecification with TimeWarp w
   lazy val hakemusRepository = new HakemusRepository(new HakuAppRepository(), ataruHakemusRepository, new AtaruHakemusEnricher(appConfig, hakuService, oppijanumerorekisteriService))
   lazy val valintatulosService = new ValintatulosService(valintarekisteriDb, sijoittelutulosService, hakemusRepository, valintarekisteriDb,
     hakuService, valintarekisteriDb, hakukohdeRecordService, valintatulosDao)
-  lazy val vastaanottoService = new VastaanottoService(hakuService, hakukohdeRecordService, valintatulosService,
-    valintarekisteriDb, appConfig.ohjausparametritService, sijoittelutulosService, hakemusRepository, valintarekisteriDb)
+  lazy val vastaanottoService = new VastaanottoService(hakuService, hakukohdeRecordService, valintatulosService, valintarekisteriDb, valintarekisteriDb, appConfig.ohjausparametritService, sijoittelutulosService, hakemusRepository, valintarekisteriDb)
   lazy val ilmoittautumisService = new IlmoittautumisService(valintatulosService,
     valintarekisteriDb, valintarekisteriDb)
 

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/VastaanottoServiceVirkailijanaSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/VastaanottoServiceVirkailijanaSpec.scala
@@ -372,7 +372,7 @@ class VastaanottoServiceVirkailijanaSpec extends ITSpecification with TimeWarp w
       ))
       val hakemuksentulos = hakemuksenTulos
       vastaanotonTulos match {
-        case Failure(cae: ConflictingAcceptancesException) => cae.conflictingVastaanottos.map(_.hakukohdeOid) must_== Vector(alinHakukohdeOid, keskimmainenHakukohdeOid)
+        case Failure(cae: ConflictingAcceptancesException) => cae.conflictingVastaanottos.map(_.hakukohdeOid).toSet must_== Set(alinHakukohdeOid, keskimmainenHakukohdeOid)
         case x => fail(s"Should have failed on several conflicting records but got $x")
       }
 

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/domain/oids.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/domain/oids.scala
@@ -3,30 +3,25 @@ package fi.vm.sade.valintatulosservice.valintarekisteri.domain
 import org.json4s.{CustomKeySerializer, CustomSerializer, Formats}
 import org.json4s.JsonAST.JString
 
-case class HakemusOid(s: String) {
-  override def toString: String = s
+trait VtsOid {
+  val s: String
+  override val toString: String = s
+  override val hashCode: Int = s.hashCode
 }
 
-case class ValintatapajonoOid(s: String) {
-  override def toString: String = s
-}
+case class HakemusOid(s: String) extends VtsOid
 
-case class HakukohdeOid(s: String) {
-  override def toString: String = s
+case class ValintatapajonoOid(s: String) extends VtsOid
+
+case class HakukohdeOid(s: String) extends VtsOid {
   def valid: Boolean = OidValidator.isOid(s)
 }
 
-case class HakuOid(s: String) {
-  override def toString: String = s
-}
+case class HakuOid(s: String) extends VtsOid
 
-case class TarjoajaOid(s: String) {
-  override def toString: String = s
-}
+case class TarjoajaOid(s: String) extends VtsOid
 
-case class HakijaOid(s: String) {
-  override def toString: String = s
-}
+case class HakijaOid(s: String) extends VtsOid
 
 class HakuOidSerializer extends CustomSerializer[HakuOid]((_: Formats) => {
   ({

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/sijoittelu/sijoitteluajonHakija.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/sijoittelu/sijoitteluajonHakija.scala
@@ -353,25 +353,29 @@ object SijoitteluajonHakijat {
                                      hyvaksytytJaHakeneetHakukohteittain: Map[HakukohdeOid, Map[ValintatapajonoOid, HyvaksytytJaHakeneet]])
 
   object ValinnantuloksetGrouped {
-    def apply(valinnantulokset: Set[Valinnantulos], countHyvaksytytJaHakeneet:Boolean = true):ValinnantuloksetGrouped =
+    def apply(valinnantulokset: Set[Valinnantulos], countHyvaksytytJaHakeneet:Boolean = true):ValinnantuloksetGrouped = {
+      val valinnantuloksetByHakemusOid = valinnantulokset.groupBy(_.hakemusOid)
       ValinnantuloksetGrouped(
-        valinnantulokset.groupBy(_.hakemusOid).map(t => t._1 -> t._2.groupBy(_.hakukohdeOid)),
-        valinnantulokset.groupBy(_.hakemusOid).map(t => t._1 -> t._2.map(_.hakukohdeOid)),
+        valinnantuloksetByHakemusOid.map(t => t._1 -> t._2.groupBy(_.hakukohdeOid)),
+        valinnantuloksetByHakemusOid.map(t => t._1 -> t._2.map(_.hakukohdeOid)),
         Option(countHyvaksytytJaHakeneet).collect { case true =>
           valinnantulokset.groupBy(_.hakukohdeOid)
             .map(t => t._1 -> t._2.groupBy(_.valintatapajonoOid).map(t => t._1 -> HyvaksytytJaHakeneet(t._2)))
         }.getOrElse(Map())
       )
+    }
   }
 
   case class HakutoiveetGrouped(hakutoiveetSijoittelussa: Map[HakemusOid, List[HakutoiveRecord]], hakutoiveOiditHakemuksittain: Map[HakemusOid, Set[HakukohdeOid]])
 
   object HakutoiveetGrouped {
-    def apply(hakutoiveet: List[HakutoiveRecord]):HakutoiveetGrouped =
+    def apply(hakutoiveet: List[HakutoiveRecord]):HakutoiveetGrouped = {
+      val hakutoiveetByHakemusOid = hakutoiveet.groupBy(_.hakemusOid)
       HakutoiveetGrouped(
-        hakutoiveet.groupBy(_.hakemusOid),
-        hakutoiveet.groupBy(_.hakemusOid).map(t => t._1 -> t._2.map(_.hakukohdeOid).toSet)
+        hakutoiveetByHakemusOid,
+        hakutoiveetByHakemusOid.map(t => t._1 -> t._2.map(_.hakukohdeOid).toSet)
       )
+    }
   }
 
   case class ValintatapajonotGrouped(valintatapajonotSijoittelussa:Map[HakemusOid,Map[HakukohdeOid, List[HakutoiveenValintatapajonoRecord]]], tilankuvausHashit:List[Int])

--- a/valinta-tulos-valintarekisteri-db/src/test/scala/fi/vm/sade/valintatulosservice/valintarekisteri/sijoittelu/ValintarekisteriForSijoitteluSpec.scala
+++ b/valinta-tulos-valintarekisteri-db/src/test/scala/fi/vm/sade/valintatulosservice/valintarekisteri/sijoittelu/ValintarekisteriForSijoitteluSpec.scala
@@ -60,7 +60,7 @@ class ValintarekisteriForSijoitteluSpec extends Specification with ITSetup with 
   "Sijoitteluajo should be stored in transaction" in {
     val wrapper = loadSijoitteluFromFixture("valintatapajono_hakijaryhma_pistetiedot", "sijoittelu/")
     wrapper.hakukohteet(0).getValintatapajonot.get(0).getHakemukset.get(0).setHakemusOid(null)
-    (valintarekisteri.tallennaSijoittelu(wrapper.sijoitteluajo, wrapper.hakukohteet.asJava, wrapper.valintatulokset.asJava) must throwA[Exception]).message must contain("null value in column \"hakemus_oid\" violates not-null constraint")
+    (valintarekisteri.tallennaSijoittelu(wrapper.sijoitteluajo, wrapper.hakukohteet.asJava, wrapper.valintatulokset.asJava) must throwA[Exception]).message must contain("java.lang.NullPointerException")
     findSijoitteluajo(wrapper.sijoitteluajo.getSijoitteluajoId) mustEqual None
   }
   "Unknown sijoitteluajo cannot be found" in {


### PR DESCRIPTION
- ei haeta vastaanottoja tallennettaessa koko haun tuloksia, vaan ainoastaan vastaanottojen sisältämien hakukohteiden. Isossa haussa tämä säästää merkittävästi ladattavan datan määrää

- hakukohteen valintatulosten hakeminen edellyttää kuitenkin haun kaikkien vastaanottojen lataamisen => tehdään tämä vain kertaalleen

- mikro-optimoidaan profiloinnin esiin nostamia hashCode- ja groupBy-kutsuja