### PR TITLE
BUG-2197: aiemmin hyväksyttynä ollut alempi toive näkyy väärin

### DIFF
--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
@@ -792,6 +792,85 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
       alemmanToiveenTulos.jonokohtaisetTulostiedot(2).tilanKuvaukset must beNone
     }
 
+    "ylimmällä toiveella julkaistu varalla ja julkaisematon hyväksytty, alempi julkaistu ehdollisesti hyväksyttynä ja muutettu hylätyksi" +
+      "-> näytetään alempi hylättynä" in {
+      useFixture("ylin-toive-hyvaksytty-toisesta-jonosta-mutta-kaksi-kolmesta-julkaistua-jonoa-alemmmassa-peruuntununeessa.json",
+        hakuFixture = hakuFixture,
+        hakemusFixtures = List( "00000441369-3"),
+        ohjausparametritFixture = "varasijasaannot-ei-viela-voimassa")
+
+      val alemmanToiveenEnsimmäisenHyväksytynJononOid = ValintatapajonoOid("14090336922663576781797489829888")
+      val alemmanToiveenToisenHyväksytynJononOid = ValintatapajonoOid("14090336922663576781797489829889")
+      val alempiToiveOid = HakukohdeOid("1.2.246.562.5.72607738904")
+      val hakijaOid = "1.2.246.562.24.14229104472"
+
+      valintarekisteriDb.runBlocking(
+        valintarekisteriDb.storeValinnantila(
+          ValinnantilanTallennus(
+            hakemusOid,
+            alemmanToiveenEnsimmäisenHyväksytynJononOid,
+            alempiToiveOid,
+            hakijaOid,
+            Hyvaksytty,
+            "testi")).
+          andThen(
+            asetaJulkaistavissa(alempiToiveOid, alemmanToiveenEnsimmäisenHyväksytynJononOid, hakemusOid, julkaistavissa = true)).
+          andThen(
+            asetaJulkaistavissa(alempiToiveOid, alemmanToiveenToisenHyväksytynJononOid, hakemusOid, julkaistavissa = true)))
+
+      valintarekisteriDb.runBlocking(
+        valintarekisteriDb.storeValinnantila(
+          ValinnantilanTallennus(
+            hakemusOid,
+            alemmanToiveenEnsimmäisenHyväksytynJononOid,
+            alempiToiveOid,
+            hakijaOid,
+            Hylatty,
+            "testi")).
+          andThen(tallennaTilankuvauksenTarkenne(
+            alempiToiveOid,
+            alemmanToiveenEnsimmäisenHyväksytynJononOid,
+            hakemusOid,
+            EiTilankuvauksenTarkennetta.tilankuvauksenTarkenne,
+            Some("Et toimittanut tutkintotodistusta ajoissa"))))
+
+      valintarekisteriDb.runBlocking(tallennaTilankuvauksenTarkenne(
+            alempiToiveOid,
+            alemmanToiveenToisenHyväksytynJononOid,
+            hakemusOid,
+            PeruuntunutHyvaksyttyYlemmalleHakutoiveelle.tilankuvauksenTarkenne))
+
+      val ylemmanToiveenTulos = getHakutoive("1.2.246.562.5.72607738903")
+      checkHakutoiveState(
+        ylemmanToiveenTulos,
+        Valintatila.kesken,
+        Vastaanottotila.kesken,
+        Vastaanotettavuustila.ei_vastaanotettavissa,
+        julkaistavissa = false)
+
+      ylemmanToiveenTulos.jonokohtaisetTulostiedot.size must_== 2
+      ylemmanToiveenTulos.jonokohtaisetTulostiedot.head.valintatila must_== Valintatila.varalla
+      ylemmanToiveenTulos.jonokohtaisetTulostiedot.head.tilanKuvaukset must beSome(Map())
+      ylemmanToiveenTulos.jonokohtaisetTulostiedot(1).valintatila must_== Valintatila.kesken
+      ylemmanToiveenTulos.jonokohtaisetTulostiedot(1).tilanKuvaukset must beNone
+
+      val alemmanToiveenTulos = getHakutoive("1.2.246.562.5.72607738904")
+      checkHakutoiveState(
+        alemmanToiveenTulos,
+        Valintatila.kesken,
+        Vastaanottotila.kesken,
+        Vastaanotettavuustila.ei_vastaanotettavissa,
+        julkaistavissa = false)
+      alemmanToiveenTulos.jonokohtaisetTulostiedot.size must_== 3
+      alemmanToiveenTulos.jonokohtaisetTulostiedot.head.valintatila must_== Valintatila.hylätty
+      alemmanToiveenTulos.jonokohtaisetTulostiedot.head.tilanKuvaukset must beSome
+      alemmanToiveenTulos.jonokohtaisetTulostiedot.head.tilanKuvaukset.get("FI") must_== "Et toimittanut tutkintotodistusta ajoissa"
+      alemmanToiveenTulos.jonokohtaisetTulostiedot(1).valintatila must_== Valintatila.kesken
+      alemmanToiveenTulos.jonokohtaisetTulostiedot(1).tilanKuvaukset must beNone
+      alemmanToiveenTulos.jonokohtaisetTulostiedot(2).valintatila must_== Valintatila.kesken
+      alemmanToiveenTulos.jonokohtaisetTulostiedot(2).tilanKuvaukset must beNone
+    }
+
     "peruuntunut, sijoittelua käyttävä korkeakouluhaku" in {
       "ylempi hyväksytty kesken, koska varasijasäännöt ei vielä voimassa -> näytetään peruuntunut keskeneräisenä" in {
         // VARALLA KESKEN true
@@ -1212,15 +1291,19 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
     hakuToive.julkaistavissa must_== julkaistavissa
   }
 
-  private def tallennaTilankuvauksenTarkenne(hakukohdeOid: HakukohdeOid, jonoOid: ValintatapajonoOid, hakemusOid: HakemusOid, tarkenne: TilankuvauksenTarkenne) = {
+  private def tallennaTilankuvauksenTarkenne(hakukohdeOid: HakukohdeOid,
+                                             jonoOid: ValintatapajonoOid,
+                                             hakemusOid: HakemusOid,
+                                             tarkenne: TilankuvauksenTarkenne,
+                                             kuvausteksti: Option[String] = None) = {
     valintarekisteriDb.storeValinnanTilanKuvaus(
       hakukohdeOid,
       jonoOid,
       hakemusOid,
       ValinnantilanTarkenne.getValinnantilanTarkenne(tarkenne),
-      syyTeksti(tarkenne, "FI"),
-      syyTeksti(tarkenne, "SV"),
-      syyTeksti(tarkenne, "EN"))
+      kuvausteksti.orElse(syyTeksti(tarkenne, "FI")),
+      kuvausteksti.orElse(syyTeksti(tarkenne, "SV")),
+      kuvausteksti.orElse(syyTeksti(tarkenne, "EN")))
   }
 
   private def asetaJulkaistavissa(hakukohdeOid: HakukohdeOid,

--- a/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
+++ b/valinta-tulos-service/src/test/scala/fi/vm/sade/valintatulosservice/local/ValintatulosServiceSpec.scala
@@ -871,6 +871,84 @@ class ValintatulosServiceSpec extends ITSpecification with TimeWarp {
       alemmanToiveenTulos.jonokohtaisetTulostiedot(2).tilanKuvaukset must beNone
     }
 
+    "ylimmällä toiveella julkaistu varalla ja julkaisematon hyväksytty, alempi julkaistu ehdollisesti hyväksyttynä ja muutettu varalle" +
+      "-> näytetään alempi varalla" in {
+      useFixture("ylin-toive-hyvaksytty-toisesta-jonosta-mutta-kaksi-kolmesta-julkaistua-jonoa-alemmmassa-peruuntununeessa.json",
+        hakuFixture = hakuFixture,
+        hakemusFixtures = List( "00000441369-3"),
+        ohjausparametritFixture = "varasijasaannot-ei-viela-voimassa")
+
+      val alemmanToiveenEnsimmäisenHyväksytynJononOid = ValintatapajonoOid("14090336922663576781797489829888")
+      val alemmanToiveenToisenHyväksytynJononOid = ValintatapajonoOid("14090336922663576781797489829889")
+      val alempiToiveOid = HakukohdeOid("1.2.246.562.5.72607738904")
+      val hakijaOid = "1.2.246.562.24.14229104472"
+
+      valintarekisteriDb.runBlocking(
+        valintarekisteriDb.storeValinnantila(
+          ValinnantilanTallennus(
+            hakemusOid,
+            alemmanToiveenEnsimmäisenHyväksytynJononOid,
+            alempiToiveOid,
+            hakijaOid,
+            Hyvaksytty,
+            "testi")).
+          andThen(
+            asetaJulkaistavissa(alempiToiveOid, alemmanToiveenEnsimmäisenHyväksytynJononOid, hakemusOid, julkaistavissa = true)).
+          andThen(
+            asetaJulkaistavissa(alempiToiveOid, alemmanToiveenToisenHyväksytynJononOid, hakemusOid, julkaistavissa = true)))
+
+      valintarekisteriDb.runBlocking(
+        valintarekisteriDb.storeValinnantila(
+          ValinnantilanTallennus(
+            hakemusOid,
+            alemmanToiveenEnsimmäisenHyväksytynJononOid,
+            alempiToiveOid,
+            hakijaOid,
+            Varalla,
+            "testi")).
+          andThen(tallennaTilankuvauksenTarkenne(
+            alempiToiveOid,
+            alemmanToiveenEnsimmäisenHyväksytynJononOid,
+            hakemusOid,
+            EiTilankuvauksenTarkennetta.tilankuvauksenTarkenne)))
+
+      valintarekisteriDb.runBlocking(tallennaTilankuvauksenTarkenne(
+            alempiToiveOid,
+            alemmanToiveenToisenHyväksytynJononOid,
+            hakemusOid,
+            PeruuntunutHyvaksyttyYlemmalleHakutoiveelle.tilankuvauksenTarkenne))
+
+      val ylemmanToiveenTulos = getHakutoive("1.2.246.562.5.72607738903")
+      checkHakutoiveState(
+        ylemmanToiveenTulos,
+        Valintatila.kesken,
+        Vastaanottotila.kesken,
+        Vastaanotettavuustila.ei_vastaanotettavissa,
+        julkaistavissa = false)
+
+      ylemmanToiveenTulos.jonokohtaisetTulostiedot.size must_== 2
+      ylemmanToiveenTulos.jonokohtaisetTulostiedot.head.valintatila must_== Valintatila.varalla
+      ylemmanToiveenTulos.jonokohtaisetTulostiedot.head.tilanKuvaukset must beSome(Map())
+      ylemmanToiveenTulos.jonokohtaisetTulostiedot(1).valintatila must_== Valintatila.kesken
+      ylemmanToiveenTulos.jonokohtaisetTulostiedot(1).tilanKuvaukset must beNone
+
+      val alemmanToiveenTulos = getHakutoive("1.2.246.562.5.72607738904")
+      checkHakutoiveState(
+        alemmanToiveenTulos,
+        Valintatila.kesken,
+        Vastaanottotila.kesken,
+        Vastaanotettavuustila.ei_vastaanotettavissa,
+        julkaistavissa = false)
+      alemmanToiveenTulos.jonokohtaisetTulostiedot.size must_== 3
+      alemmanToiveenTulos.jonokohtaisetTulostiedot.head.valintatila must_== Valintatila.varalla
+      alemmanToiveenTulos.jonokohtaisetTulostiedot.head.tilanKuvaukset must beSome
+      alemmanToiveenTulos.jonokohtaisetTulostiedot.head.tilanKuvaukset.get("FI") must_== ""
+      alemmanToiveenTulos.jonokohtaisetTulostiedot(1).valintatila must_== Valintatila.kesken
+      alemmanToiveenTulos.jonokohtaisetTulostiedot(1).tilanKuvaukset must beNone
+      alemmanToiveenTulos.jonokohtaisetTulostiedot(2).valintatila must_== Valintatila.kesken
+      alemmanToiveenTulos.jonokohtaisetTulostiedot(2).tilanKuvaukset must beNone
+    }
+
     "peruuntunut, sijoittelua käyttävä korkeakouluhaku" in {
       "ylempi hyväksytty kesken, koska varasijasäännöt ei vielä voimassa -> näytetään peruuntunut keskeneräisenä" in {
         // VARALLA KESKEN true

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/impl/ValinnantulosRepositoryImpl.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/impl/ValinnantulosRepositoryImpl.scala
@@ -91,7 +91,13 @@ trait ValinnantulosRepositoryImpl extends ValinnantulosRepository with Valintare
                   and th.valintatapajono_oid = vth.valintatapajono_oid
                   and th.julkaistavissa = 'true'
                   and th.system_time && vth.system_time
-                  limit 1))""".as[String].headOption).map(ValintatapajonoOid)
+                  limit 1))
+        and not exists
+          (select * from valinnantilat vt_curr
+           where vt_curr.valintatapajono_oid = vth.valintatapajono_oid and
+                 vt_curr.hakemus_oid = vth.hakemus_oid and
+                 vt_curr.hakukohde_oid = vth.hakukohde_oid and
+                 vt_curr.tila = 'Hylatty')""".as[String].headOption).map(ValintatapajonoOid)
   }
 
   private def getValinnantulosMuutos(hakemusOid: HakemusOid, valintatapajonoOid: ValintatapajonoOid): MuutosDBIOAction = {

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/impl/ValinnantulosRepositoryImpl.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/impl/ValinnantulosRepositoryImpl.scala
@@ -80,7 +80,8 @@ trait ValinnantulosRepositoryImpl extends ValinnantulosRepository with Valintare
                   and t.hakukohde_oid = vth.hakukohde_oid
                   and t.valintatapajono_oid = vth.valintatapajono_oid
                   and t.julkaistavissa = 'true'
-                  and lower(t.system_time) <@ vth.system_time
+                  and ((lower(t.system_time) <@ vth.system_time)
+                    or (lower(t.system_time) < lower(vth.system_time)))
                 limit 1)
             or (
                 select true

--- a/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/impl/ValinnantulosRepositoryImpl.scala
+++ b/valinta-tulos-valintarekisteri-db/src/main/scala/fi/vm/sade/valintatulosservice/valintarekisteri/db/impl/ValinnantulosRepositoryImpl.scala
@@ -80,8 +80,7 @@ trait ValinnantulosRepositoryImpl extends ValinnantulosRepository with Valintare
                   and t.hakukohde_oid = vth.hakukohde_oid
                   and t.valintatapajono_oid = vth.valintatapajono_oid
                   and t.julkaistavissa = 'true'
-                  and ((lower(t.system_time) <@ vth.system_time)
-                    or (lower(t.system_time) < lower(vth.system_time)))
+                  and t.system_time && vth.system_time
                 limit 1)
             or (
                 select true


### PR DESCRIPTION
* Jos alempi julkaistu hyväksytty tulos oli ollut aiemmin julkaistuna jossain muussa kuin hyväksytyssä tilassa (tyypillisesti varalla), kysely ei huomioinut sitä aiempana julkaistuna => näytettiinkin "kesken" sen sijaan, että olisi näytetty "Hyväksytty, odottaa ylempiä"

* Jos alempi julkaistu hyväksytty tulos muuttui myöhemmin hylätyksi, niin se näkyikin "hyväksytty, odottaa ylempiä"; korjauksena ei huomioida sellaisia jonon aiempia hyväksyntöjä, joiden tila on nyt hylätty.